### PR TITLE
Fix typos and duplicate asset definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist/
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# macOS
+.DS_Store

--- a/src/scripts/components/HelpFlower.ts
+++ b/src/scripts/components/HelpFlower.ts
@@ -40,7 +40,7 @@ export class HelpFlower extends BaseCaptureableObject {
                 break;
             case "gather":
                 this.sprite = PIXI.Sprite.from("flower3");
-                this.message = "Ghather!";
+                this.message = "Gather!";
                 this.messageJP = "あつまれ！";
                 this.description = "Gather the butterflies by color";
                 this.descriptionJP = "ちょうちょをあつめる";

--- a/src/scripts/components/StageInformation.ts
+++ b/src/scripts/components/StageInformation.ts
@@ -12,8 +12,8 @@ export class StageInformation {
     stageButterflyCount: number = 10;
     butterflySize: string = "random";
     isButterflyColorChange: boolean = false;
-    muptipleButterflyRate: number = 0;
-    maxMultiplateRate: number = 1;
+    multipleButterflyRate: number = 0;
+    maxMultipleRate: number = 1;
     helpObjectNum: number = 0;
     hasBonusButterfly: boolean = false;
 
@@ -102,8 +102,8 @@ export class StageInformation {
             1,
         )[0];
         this.isButterflyColorChange = Utility.random(0, 1) === 1;
-        this.muptipleButterflyRate = Utility.random(15, 20) / 100;
-        this.maxMultiplateRate = 3;
+        this.multipleButterflyRate = Utility.random(15, 20) / 100;
+        this.maxMultipleRate = 3;
         this.helpObjectNum = Utility.random(4, 8);
         this.hasBonusButterfly = false;
     }

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -649,7 +649,7 @@ export class GameplayState extends StateBase {
                     });
                 }
             });
-            this.gatherElapsedTime = Const.GATHHER_EFFECT_TIME_MS;
+            this.gatherElapsedTime = Const.GATHER_EFFECT_TIME_MS;
 
             // デバッグモードの場合は、集まる範囲を表示
             if (DEBUG_MODE) {
@@ -665,7 +665,7 @@ export class GameplayState extends StateBase {
                     this.container.addChildAt(circle, 1);
                     setTimeout(() => {
                         this.container.removeChild(circle);
-                    }, Const.GATHHER_EFFECT_TIME_MS);
+                    }, Const.GATHER_EFFECT_TIME_MS);
                 });
             }
         } else {
@@ -686,10 +686,10 @@ export class GameplayState extends StateBase {
             ? randomColors[1]
             : mainColor;
         const isMultiple = Utility.isTrueRandom(
-            this.stageInfo.muptipleButterflyRate * 100,
+            this.stageInfo.multipleButterflyRate * 100,
         );
         const multiplication = isMultiple
-            ? Utility.random(2, this.stageInfo.maxMultiplateRate)
+            ? Utility.random(2, this.stageInfo.maxMultipleRate)
             : 1;
 
         const newButterfly = new Butterfly(

--- a/src/scripts/utils/Const.ts
+++ b/src/scripts/utils/Const.ts
@@ -27,7 +27,7 @@ export const HELP_FLOWER_TYPES = [
 ] as const;
 
 export const LONG_LOOP_EFFECT_TIME_MS = 5000;
-export const GATHHER_EFFECT_TIME_MS = 10000;
+export const GATHER_EFFECT_TIME_MS = 10000;
 export const FREEZE_EFFECT_TIME_MS = 3000;
 
 export const imageSrcs = [
@@ -46,7 +46,6 @@ export const imageSrcs = [
     { alias: "pencil", src: `${BASE_URL}assets/pencil.png` },
     { alias: "sticky", src: `${BASE_URL}assets/sticky.png` },
     { alias: "sun", src: `${BASE_URL}assets/sun.png` },
-    { alias: "moon", src: `${BASE_URL}assets/moon.png` },
     { alias: "sunset_spritesheet", src: `${BASE_URL}assets/sunset.json` },
     { alias: "sunset", src: `${BASE_URL}assets/sunset.png` },
     { alias: "flower1", src: `${BASE_URL}assets/flower1.png` },

--- a/src/scripts/utils/stage-config-debug.json
+++ b/src/scripts/utils/stage-config-debug.json
@@ -17,8 +17,8 @@
         "stageButterflyCount": 15,
         "butterflySize": "random",
         "isButterflyColorChange": true,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.2,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.2,
         "helpObjectNum": 10,
         "hasBonusButterfly": true
     },
@@ -31,8 +31,8 @@
         "stageButterflyCount": 12,
         "butterflySize": "medium",
         "isButterflyColorChange": true,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.2,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.2,
         "helpObjectNum": 3
     },
     {
@@ -44,8 +44,8 @@
         "stageButterflyCount": 14,
         "butterflySize": "large",
         "isButterflyColorChange": true,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.2,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.2,
         "helpObjectNum": 3
     }
 ]

--- a/src/scripts/utils/stage-config.json
+++ b/src/scripts/utils/stage-config.json
@@ -62,8 +62,8 @@
         "stageButterflyCount": 10,
         "butterflySize": "large",
         "isButterflyColorChange": true,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.15,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.15,
         "helpObjectNum": 2
     },
     {
@@ -75,8 +75,8 @@
         "stageButterflyCount": 10,
         "butterflySize": "medium",
         "isButterflyColorChange": false,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.15,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.15,
         "helpObjectNum": 2
     },
     {
@@ -88,8 +88,8 @@
         "stageButterflyCount": 10,
         "butterflySize": "large",
         "isButterflyColorChange": true,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.15,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.15,
         "helpObjectNum": 2
     },
     {
@@ -101,8 +101,8 @@
         "stageButterflyCount": 12,
         "butterflySize": "small",
         "isButterflyColorChange": false,
-        "maxMultiplateRate": 2,
-        "muptipleButterflyRate": 0.2,
+        "maxMultipleRate": 2,
+        "multipleButterflyRate": 0.2,
         "helpObjectNum": 3
     },
     {
@@ -114,8 +114,8 @@
         "stageButterflyCount": 15,
         "butterflySize": "random",
         "isButterflyColorChange": true,
-        "maxMultiplateRate": 3,
-        "muptipleButterflyRate": 0.15,
+        "maxMultipleRate": 3,
+        "multipleButterflyRate": 0.15,
         "helpObjectNum": 4
     }
 ]

--- a/tests/integration/PowerUpSystem.test.ts
+++ b/tests/integration/PowerUpSystem.test.ts
@@ -13,7 +13,7 @@ vi.mock("pixi.js", () => ({
 vi.mock("../../src/scripts/utils/Const", () => ({
     FREEZE_EFFECT_TIME_MS: 3000,
     LONG_LOOP_EFFECT_TIME_MS: 10000,
-    GATHHER_EFFECT_TIME_MS: 10000,
+    GATHER_EFFECT_TIME_MS: 10000,
 }));
 
 // Test implementations for power-up system integration


### PR DESCRIPTION
## 概要 / Summary

コードベース内のタイポと重複アセット定義を修正します。#33 のタスク1〜2に相当します。
Fix typos and a duplicate asset definition across the codebase. Covers tasks 1-2 of #33.

close: #28

## 変更内容 / Changes

- `GATHHER_EFFECT_TIME_MS` → `GATHER_EFFECT_TIME_MS`(Const.ts、GameplayState.ts、テストのモック定数)
- `muptipleButterflyRate` → `multipleButterflyRate` / `maxMultiplateRate` → `maxMultipleRate`(StageInformation.ts、GameplayState.ts)
- **stage-config.json / stage-config-debug.json のキー名も連動リネーム** — `StageInformation.setConfig()` が `key in this` で動的マッピングしているため、JSON側を変えないと設定値が反映されなくなるバグになります / JSON config keys renamed together, since `setConfig()` maps keys dynamically — renaming only the class properties would silently break config loading
- ユーザー向けメッセージ `"Ghather!"` → `"Gather!"`(HelpFlower.ts)
- Const.ts の "moon" アセット重複定義を削除(1つは残存、`Sprite.from("moon")` は引き続き解決可能)
- `.gitignore` に `.DS_Store` を追加

## 検証 / Verification

- 旧名(`GATHHER` / `muptiple` / `Multiplate` / `Ghather`)の残存ゼロを `git grep -iE` で確認 / Verified no stale references remain
- ユニット/統合テスト 265件 全て成功 / All 265 unit & integration tests pass
- lint (prettier + eslint) クリーン / Lint clean
- レビューエージェントによるレビュー済み(指摘ゼロ) / Reviewed by the review agent (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)