### PR TITLE
Improve type safety: eliminate any types and non-null assertions

### DIFF
--- a/src/scripts/components/LineDrawer.ts
+++ b/src/scripts/components/LineDrawer.ts
@@ -15,8 +15,7 @@ export class LineDrawer extends EventEmitter {
     readonly originalLineColor: number = 0xffffff;
     private lineDrawTime: number;
     private lineColor: number;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    pointerMoveHandler: any;
+    pointerMoveHandler: ((e: PIXI.FederatedPointerEvent) => void) | null = null;
 
     constructor(app: PIXI.Application, color: number = 0xffffff) {
         super();
@@ -34,7 +33,6 @@ export class LineDrawer extends EventEmitter {
         if (this.pointerMoveHandler) {
             this.app.stage.removeEventListener(
                 "pointermove",
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 this.pointerMoveHandler,
             );
         }
@@ -46,12 +44,9 @@ export class LineDrawer extends EventEmitter {
     }
 
     private setupInteraction(): void {
-        this.pointerMoveHandler = (e: {
-            data: { global: { x: number; y: number } };
-        }) => {
-            this.onPointerMove(e.data.global.x, e.data.global.y);
+        this.pointerMoveHandler = (e: PIXI.FederatedPointerEvent) => {
+            this.onPointerMove(e.global.x, e.global.y);
         };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this.app.stage.addEventListener("pointermove", this.pointerMoveHandler);
     }
 

--- a/src/scripts/components/StageInformation.ts
+++ b/src/scripts/components/StageInformation.ts
@@ -3,6 +3,27 @@ import * as Utility from "../utils/Utility";
 import stageConfig from "../utils/stage-config.json";
 import stageDebugConfig from "../utils/stage-config-debug.json";
 
+interface StageConfig {
+    // levelとdebugはJSON上のドキュメント用途で、コードからは参照されない
+    // (実際のステージ番号はsetConfigの引数levelで決まる)
+    level: number;
+    debug?: boolean;
+    butterflyColorNum: number;
+    needCount: number;
+    stageButterflyCount: number;
+    butterflySize: string;
+    isButterflyColorChange: boolean;
+    // 序盤ステージの設定には存在しないキー(存在しない場合は前ステージの値を引き継ぐ)
+    stageTime?: number;
+    multipleButterflyRate?: number;
+    maxMultipleRate?: number;
+    helpObjectNum?: number;
+    hasBonusButterfly?: boolean;
+}
+
+const stageConfigs: StageConfig[] = stageConfig;
+const stageDebugConfigs: StageConfig[] = stageDebugConfig;
+
 export class StageInformation {
     //settings
     level: number = 0;
@@ -37,21 +58,27 @@ export class StageInformation {
     }
 
     private setConfig(level: number): void {
-        let config = DEBUG_MODE ? stageDebugConfig[level] : stageConfig[level];
+        const configs = DEBUG_MODE ? stageDebugConfigs : stageConfigs;
+        let config = configs[level];
         if (config === undefined) {
             // 最終まで来た場合はとりあえず＋２
-            config = DEBUG_MODE
-                ? stageDebugConfig[stageDebugConfig.length - 1]
-                : stageConfig[stageConfig.length - 1];
+            config = configs[configs.length - 1];
             config.needCount += 2;
         }
 
-        Object.keys(config).forEach((key) => {
-            if (key in this) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                (this as any)[key] = config[key as keyof typeof config];
-            }
-        });
+        this.needCount = config.needCount;
+        this.stageButterflyCount = config.stageButterflyCount;
+        this.butterflySize = config.butterflySize;
+        this.isButterflyColorChange = config.isButterflyColorChange;
+        // 設定に無いキーは前ステージの値を引き継ぐ
+        this.stageTime = config.stageTime ?? this.stageTime;
+        this.multipleButterflyRate =
+            config.multipleButterflyRate ?? this.multipleButterflyRate;
+        this.maxMultipleRate = config.maxMultipleRate ?? this.maxMultipleRate;
+        this.helpObjectNum = config.helpObjectNum ?? this.helpObjectNum;
+        this.hasBonusButterfly =
+            config.hasBonusButterfly ?? this.hasBonusButterfly;
+
         this.level = level;
         this.butterflyColors = Utility.chooseAtRandom(
             [...Const.COLOR_LIST],

--- a/src/scripts/game.ts
+++ b/src/scripts/game.ts
@@ -36,7 +36,7 @@ let landscapePrompt: LandscapePrompt | null = null;
     wf.type = "text/javascript";
     wf.async = true;
     const s = document.getElementsByTagName("script")[0];
-    s.parentNode!.insertBefore(wf, s);
+    s.parentNode?.insertBefore(wf, s);
 })();
 /* eslint-enabled */
 window.WebFontConfig = {
@@ -101,21 +101,23 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 function setUp() {
-    const appView = app.canvas as HTMLCanvasElement | null;
-    appView!.id = "app";
-    if (appView) {
-        document.getElementById("loading")!.style.display = "none";
+    // app.init()完了後なのでcanvasは必ず存在する
+    app.canvas.id = "app";
 
-        const manager = new GameStateManager(app);
-        const startState = new StartState(manager);
-        manager.setState(startState);
-
-        app.ticker.add(() => {
-            manager.update(app.ticker.deltaMS);
-            manager.render();
-        });
-        // カーソルのスタイルを変更
-        const cursorIcon = `url(\'${BASE_URL}assets/pencil.png\'),auto`;
-        app.renderer.events.cursorStyles.default = cursorIcon;
+    const loading = document.getElementById("loading");
+    if (loading) {
+        loading.style.display = "none";
     }
+
+    const manager = new GameStateManager(app);
+    const startState = new StartState(manager);
+    manager.setState(startState);
+
+    app.ticker.add(() => {
+        manager.update(app.ticker.deltaMS);
+        manager.render();
+    });
+    // カーソルのスタイルを変更
+    const cursorIcon = `url(\'${BASE_URL}assets/pencil.png\'),auto`;
+    app.renderer.events.cursorStyles.default = cursorIcon;
 }

--- a/src/scripts/scenes/RuleState.ts
+++ b/src/scripts/scenes/RuleState.ts
@@ -17,8 +17,7 @@ export class RuleState extends StateBase {
     private backButton: Button;
     private nextButton: Button;
     private page: number = 0;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private pageInfos: any[] = [];
+    private pageInfos: PIXI.Container[] = [];
     private defaultTextStyle: PIXI.TextStyleOptions = {
         fontFamily: Const.FONT_ENGLISH,
         fontSize: 22,
@@ -852,7 +851,6 @@ export class RuleState extends StateBase {
         this.helpFlowers = [];
         await Promise.all(
             this.pageInfos.map((pageInfo) => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 return this.fadeOut(pageInfo, 0.05);
             }),
         );

--- a/tests/setup/test-setup.ts
+++ b/tests/setup/test-setup.ts
@@ -30,6 +30,10 @@ Object.defineProperty(window, "HTMLCanvasElement", {
     })),
 });
 
+// Webpack DefinePlugin globals (see webpack.config.cjs)
+vi.stubGlobal("BASE_URL", "/");
+vi.stubGlobal("DEBUG_MODE", false);
+
 // Global test setup
 beforeEach(() => {
     // Reset all mocks before each test

--- a/tests/unit/components/StageInformation.test.ts
+++ b/tests/unit/components/StageInformation.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { StageInformation } from "../../../src/scripts/components/StageInformation";
+
+describe("StageInformation", () => {
+    describe("constructor", () => {
+        it("should load level 1 config from stage-config.json", () => {
+            const si = new StageInformation();
+
+            expect(si.level).toBe(1);
+            expect(si.stageTime).toBe(60);
+            expect(si.needCount).toBe(8);
+            expect(si.stageButterflyCount).toBe(8);
+            expect(si.butterflySize).toBe("large");
+            expect(si.isButterflyColorChange).toBe(false);
+            expect(si.butterflyColors).toHaveLength(2);
+            expect(si.captureCount).toBe(0);
+            expect(si.stagePoint).toBe(0);
+        });
+
+        it("should keep defaults for keys absent in early stage configs", () => {
+            const si = new StageInformation();
+
+            expect(si.multipleButterflyRate).toBe(0);
+            expect(si.maxMultipleRate).toBe(1);
+            expect(si.helpObjectNum).toBe(0);
+        });
+    });
+
+    describe("next", () => {
+        it("should advance to the next level config", () => {
+            const si = new StageInformation();
+            si.next();
+
+            expect(si.level).toBe(2);
+            expect(si.needCount).toBe(10);
+            expect(si.butterflySize).toBe("medium");
+            expect(si.butterflyColors).toHaveLength(3);
+        });
+
+        it("should apply multi-butterfly keys once configs define them (level 6)", () => {
+            const si = new StageInformation();
+            while (si.level < 6) {
+                si.next();
+            }
+
+            expect(si.multipleButterflyRate).toBeCloseTo(0.15);
+            expect(si.maxMultipleRate).toBe(2);
+            expect(si.helpObjectNum).toBe(2);
+        });
+
+        it("should set hasBonusButterfly on every 5th level", () => {
+            const si = new StageInformation();
+            while (si.level < 5) {
+                si.next();
+            }
+            expect(si.hasBonusButterfly).toBe(true);
+
+            si.next();
+            expect(si.hasBonusButterfly).toBe(false);
+        });
+
+        it("should reuse the last config with needCount increased by 2 beyond the final level", () => {
+            const si = new StageInformation();
+            while (si.level < 10) {
+                si.next();
+            }
+            const lastStageValues = {
+                stageButterflyCount: si.stageButterflyCount,
+                butterflySize: si.butterflySize,
+            };
+
+            si.next(); // level 11: beyond the last config entry
+            const overflowNeedCount = si.needCount;
+            expect(si.level).toBe(11);
+            expect(si.stageButterflyCount).toBe(
+                lastStageValues.stageButterflyCount,
+            );
+            expect(si.butterflySize).toBe(lastStageValues.butterflySize);
+
+            si.next(); // level 12: +2 every overflow level
+            expect(si.needCount).toBe(overflowNeedCount + 2);
+        });
+    });
+
+    describe("calcScore", () => {
+        it("should mark clear and add bonus when captureCount exceeds needCount", () => {
+            const si = new StageInformation();
+            si.captureCount = si.needCount + 3;
+            si.stagePoint = 500;
+
+            si.calcScore();
+
+            expect(si.isClear).toBe(true);
+            expect(si.bonusCount).toBe(3);
+            expect(si.bonusPoint).toBe(300);
+            expect(si.stageTotalScore).toBe(800);
+            expect(si.totalScore).toBe(800);
+        });
+
+        it("should not clear nor add bonus when captureCount is short", () => {
+            const si = new StageInformation();
+            si.captureCount = si.needCount - 1;
+            si.stagePoint = 200;
+
+            si.calcScore();
+
+            expect(si.isClear).toBe(false);
+            expect(si.bonusCount).toBe(0);
+            expect(si.stageTotalScore).toBe(200);
+        });
+    });
+
+    describe("bonusStage", () => {
+        it("should enter bonus mode with randomized settings in expected ranges", () => {
+            const si = new StageInformation();
+            si.bonusStage();
+
+            expect(si.bonusFlag).toBe(true);
+            expect(si.isClear).toBe(false);
+            expect(si.captureCount).toBe(0);
+            expect(si.needCount).toBe(-1);
+            expect(si.stageTime).toBe(60);
+            expect(si.butterflyColors.length).toBeGreaterThanOrEqual(3);
+            expect(si.butterflyColors.length).toBeLessThanOrEqual(4);
+            expect(si.stageButterflyCount).toBeGreaterThanOrEqual(12);
+            expect(si.stageButterflyCount).toBeLessThanOrEqual(18);
+            expect(si.multipleButterflyRate).toBeGreaterThanOrEqual(0.15);
+            expect(si.multipleButterflyRate).toBeLessThanOrEqual(0.2);
+            expect(si.maxMultipleRate).toBe(3);
+            expect(si.hasBonusButterfly).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## 概要 / Summary

`src/` から `any` 型と non-null アサーション(`!`)を全廃し、Phase 1(型安全性・実行時安全性)の中核を完了します。
Eliminate all `any` types and non-null assertions from `src/`, completing the core of refactoring Phase 1.

close: #24
close: #27

#30 についても、残タスク(GameEvents インターフェース群などの大規模な型定義追加)は現状のコード規模では不要と判断しており、close を推奨します(判断はお任せします)。
For #30, the remaining aspirational items (e.g., a GameEvents interface layer) look unnecessary at the current codebase size — closing it is recommended, but left to your judgement.

## 変更内容 / Changes

- **StageInformation**: `(this as any)[key]` による動的 config 割当を `StageConfig` インターフェース + 明示的代入に置換。「JSON エントリに無いキーは前ステージの値を引き継ぐ」現行挙動を `??` で保存
  Replace dynamic config mapping with a typed `StageConfig` interface + explicit assignments; keys absent from a stage entry still inherit the previous stage's values (behavior preserved)
- **LineDrawer**: `pointerMoveHandler: any` → `PIXI.FederatedPointerEvent`、非推奨の `e.data.global` → `e.global` (v8 API)
- **RuleState**: `pageInfos: any[]` → `PIXI.Container[]`
- **game.ts**: non-null アサーション3箇所を null チェック / optional chaining に置換
- **tests**: リファクタ前に書いた StageInformation の特性テスト9件を追加(TDD)。test-setup に webpack DefinePlugin グローバル(`BASE_URL` / `DEBUG_MODE`)のスタブを追加

## 検証 / Verification

- `src/` に `any` / `!` の残存ゼロ(grep 確認) / No `any` or `!` left in `src/`
- `tsc --noEmit -p tsconfig.build.json` クリーン / Build typecheck clean
- ユニット/統合テスト 274件(既存265 + 新規9)全て成功 / All 274 tests pass
- レビューエージェントによるレビュー済み(マージ可、nit 1件は反映済み) / Reviewed by the review agent; the one nit is addressed

## 発見した潜在課題(別issue向けメモ)/ Known follow-ups (out of scope)

1. 最終ステージ超過時の `config.needCount += 2` がインポート済み JSON オブジェクトを破壊的に変更しており、周回ごとに累積します(現行挙動として特性テストで固定済み。修正するなら #31 で)
   The needCount escalation beyond the final stage mutates the shared JSON object cumulatively — characterized in tests; candidates for #31
2. テストのモック型エラー(`tsc --noEmit` で74件、実行には無害)が既存のまま残っています。別コミットで `typecheck` スクリプト追加とともに解消可能
   Pre-existing mock type errors in test files (harmless at runtime) remain; can be fixed separately with a `typecheck` script
3. stage-config JSON のスキーマバリデーションは未実装(必須キー欠落は現状無警告)
   No runtime schema validation for stage-config JSON yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)