### PR TITLE
Fix memory leaks, ghost segments, and missing error handling (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist/
 
 # macOS
 .DS_Store
+
+# Claude Code agent worktrees
+.claude/worktrees/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tsEsLintParser from "@typescript-eslint/parser";
 
 export default [
     // 無視するファイルを指定（従来の .eslintignore に相当）
-    { ignores: ["dist", "**/*.cjs"] },
+    { ignores: ["dist", "**/*.cjs", ".claude/worktrees"] },
     // eslint:recommendedに相当
     js.configs.recommended,
     // eslint-config-prettierはrulesを持つオブジェクトなので、ここに並べられる

--- a/src/scripts/components/BaseCaptureableObject.ts
+++ b/src/scripts/components/BaseCaptureableObject.ts
@@ -3,6 +3,7 @@ import * as PIXI from "pixi.js";
 export abstract class BaseCaptureableObject extends PIXI.Container {
     protected hitAreaSize: number = 10;
     protected hitRate: number = 0.6;
+    private isDeleting: boolean = false;
 
     constructor() {
         super();
@@ -54,14 +55,24 @@ export abstract class BaseCaptureableObject extends PIXI.Container {
     }
 
     delete(speed: number = 0.02): void {
+        // 二重呼び出しでrAFループが多重に走らないようにする
+        if (this.isDeleting) {
+            return;
+        }
+        this.isDeleting = true;
+
         // アニメーションで透明度を徐々に減少させる
         const fadeOut = () => {
+            // 外部で既に破棄されていたらループを止める(リーク防止)
+            if (this.destroyed) {
+                return;
+            }
             if (this.alpha > 0) {
                 this.alpha -= speed;
                 requestAnimationFrame(fadeOut);
             } else {
-                this.destroy();
                 this.removeFromParent();
+                this.destroy();
             }
         };
         fadeOut();

--- a/src/scripts/components/Butterfly.ts
+++ b/src/scripts/components/Butterfly.ts
@@ -130,13 +130,17 @@ export class Butterfly extends BaseCaptureableObject {
 
     appear(fadeIn: boolean = true): void {
         if (fadeIn) {
-            const fadeIn = () => {
-                if (this.alpha <= 1) {
-                    this.alpha += 0.07;
-                    requestAnimationFrame(fadeIn);
+            const fadeInStep = () => {
+                // 破棄済みならループを止める(リーク防止)
+                if (this.destroyed) {
+                    return;
+                }
+                if (this.alpha < 1) {
+                    this.alpha = Math.min(this.alpha + 0.07, 1);
+                    requestAnimationFrame(fadeInStep);
                 }
             };
-            fadeIn();
+            fadeInStep();
         } else {
             this.alpha = 1;
         }
@@ -202,7 +206,7 @@ export class Butterfly extends BaseCaptureableObject {
             }
 
             // 縦方向
-            if (this.yDiretion < top && this.y <= this.sprite.height + top) {
+            if (this.yDiretion < 0 && this.y <= this.sprite.height + top) {
                 // 上端に到達したら下に向かう
                 this.yFrame = 0;
                 this.yDiretion = Math.abs(this.yDiretion);

--- a/src/scripts/components/LineDrawer.ts
+++ b/src/scripts/components/LineDrawer.ts
@@ -83,16 +83,18 @@ export class LineDrawer extends EventEmitter {
             };
             this.segments.push(segmentObj);
 
-            // セグメントを削除
+            // 寿命が切れたら自分と自分より前のセグメントをすべて破棄する
+            // (lineDrawTime変更対策 + 見えない線分がループ判定に残らないように)
             setTimeout(() => {
-                this.app.stage.removeChild(segment);
-                // 自分より前のセグメントをすべてdestroyする(lineDrawTime変更対策)
                 const index = this.segments.indexOf(segmentObj);
-                for (let i = 0; i < index; i++) {
-                    this.app.stage.removeChild(this.segments[i].graphics);
-                    this.segments[i].graphics.destroy();
-                    this.segments.shift();
+                if (index === -1) {
+                    // clearAllSegmentsで既に破棄済み
+                    return;
                 }
+                this.segments.splice(0, index + 1).forEach((expired) => {
+                    this.app.stage.removeChild(expired.graphics);
+                    expired.graphics.destroy();
+                });
             }, this.lineDrawTime);
 
             // ループ完成のチェック
@@ -182,6 +184,10 @@ export class LineDrawer extends EventEmitter {
 
         // アニメーションで透明度を徐々に減少させる
         const fadeOut = () => {
+            // 状態遷移などで既に破棄されていたらループを止める(リーク防止)
+            if (fillGraphics.destroyed) {
+                return;
+            }
             if (fillGraphics.alpha > 0) {
                 fillGraphics.alpha -= 0.01;
                 requestAnimationFrame(fadeOut);

--- a/src/scripts/components/StageInformation.ts
+++ b/src/scripts/components/StageInformation.ts
@@ -60,13 +60,16 @@ export class StageInformation {
     private setConfig(level: number): void {
         const configs = DEBUG_MODE ? stageDebugConfigs : stageConfigs;
         let config = configs[level];
+        // 最終ステージを超えたら、超過1レベルごとに必要数+2
+        // (共有configオブジェクトは変更しない)
+        let overflowNeedCount = 0;
         if (config === undefined) {
-            // 最終まで来た場合はとりあえず＋２
-            config = configs[configs.length - 1];
-            config.needCount += 2;
+            const lastLevel = configs.length - 1;
+            config = configs[lastLevel];
+            overflowNeedCount = (level - lastLevel) * 2;
         }
 
-        this.needCount = config.needCount;
+        this.needCount = config.needCount + overflowNeedCount;
         this.stageButterflyCount = config.stageButterflyCount;
         this.butterflySize = config.butterflySize;
         this.isButterflyColorChange = config.isButterflyColorChange;

--- a/src/scripts/game.ts
+++ b/src/scripts/game.ts
@@ -88,7 +88,17 @@ window.addEventListener("load", async () => {
         touchHandler.init();
     }
 
-    await PIXI.Assets.load(imageSrcs).then(setUp);
+    try {
+        await PIXI.Assets.load(imageSrcs);
+        setUp();
+    } catch (error) {
+        console.error("Failed to load game assets:", error);
+        const loading = document.getElementById("loading");
+        if (loading) {
+            loading.textContent =
+                "Failed to load the game. Please reload the page.";
+        }
+    }
 });
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/src/scripts/scenes/BaseState.ts
+++ b/src/scripts/scenes/BaseState.ts
@@ -55,6 +55,13 @@ export class StateBase {
         return new Promise((resolve) => {
             const ticker = new PIXI.Ticker();
             ticker.add(() => {
+                // 対象が破棄されたらtickerを道連れにしない(リーク防止)
+                if (container.destroyed) {
+                    ticker.stop();
+                    ticker.destroy();
+                    resolve();
+                    return;
+                }
                 if (container.alpha > alpha) {
                     container.alpha -= (fadespeed * ticker.deltaMS) / 16;
                     if (container.alpha < alpha) {
@@ -78,6 +85,12 @@ export class StateBase {
         return new Promise((resolve) => {
             const ticker = new PIXI.Ticker();
             ticker.add(() => {
+                if (container.destroyed) {
+                    ticker.stop();
+                    ticker.destroy();
+                    resolve();
+                    return;
+                }
                 if (container.alpha < alpha) {
                     container.alpha += (fadespeed * ticker.deltaMS) / 16;
                     if (container.alpha > alpha) {
@@ -102,6 +115,12 @@ export class StateBase {
         return new Promise((resolve) => {
             const ticker = new PIXI.Ticker();
             ticker.add(() => {
+                if (container.destroyed) {
+                    ticker.stop();
+                    ticker.destroy();
+                    resolve();
+                    return;
+                }
                 if (isUp) {
                     if (container.y > reachPointY) {
                         container.y -= speed * ticker.deltaMS;

--- a/src/scripts/scenes/GameStateManager.ts
+++ b/src/scripts/scenes/GameStateManager.ts
@@ -2,7 +2,7 @@ import { GameState } from "./GameState";
 import * as PIXI from "pixi.js";
 
 export class GameStateManager {
-    private currentState!: GameState;
+    private currentState: GameState | null = null;
     public app: PIXI.Application;
 
     constructor(app: PIXI.Application) {
@@ -17,14 +17,17 @@ export class GameStateManager {
             this.currentState.onExit();
         }
         this.currentState = newState;
-        this.currentState.onEnter();
+        // onEnterをasyncで実装している状態もあるため、失敗を握りつぶさない
+        Promise.resolve(this.currentState.onEnter()).catch((error: unknown) => {
+            console.error("Failed to enter state:", error);
+        });
     }
 
     update(delta: number) {
-        this.currentState.update(delta);
+        this.currentState?.update(delta);
     }
 
     render() {
-        this.currentState.render();
+        this.currentState?.render();
     }
 }

--- a/src/scripts/scenes/RuleState.ts
+++ b/src/scripts/scenes/RuleState.ts
@@ -138,9 +138,13 @@ export class RuleState extends StateBase {
     // LineDrawerのループエリアが完成したときのハンドラ
     private async handleLoopAreaCompleted(loopArea: PIXI.Graphics) {
         if (this.backButton.isHit(loopArea)) {
-            void this.selectBackButton();
+            this.selectBackButton().catch((error: unknown) => {
+                console.error("Failed to select back button:", error);
+            });
         } else if (this.nextButton.isHit(loopArea)) {
-            void this.selectNextButton();
+            this.selectNextButton().catch((error: unknown) => {
+                console.error("Failed to select next button:", error);
+            });
         }
         if (this.practiceMode) {
             // loopArea内にいる蝶を取得

--- a/src/scripts/scenes/StartState.ts
+++ b/src/scripts/scenes/StartState.ts
@@ -176,10 +176,14 @@ export class StartState extends StateBase {
     private handleLoopAreaCompleted(loopArea: PIXI.Graphics) {
         if (this.ruleButton.isHit(loopArea)) {
             this.ruleButton.selected();
-            void this.onRuleSelected();
+            this.onRuleSelected().catch((error: unknown) => {
+                console.error("Failed to open rules:", error);
+            });
         } else if (this.startButton.isHit(loopArea)) {
             this.startButton.selected();
-            void this.onStartGameSelected();
+            this.onStartGameSelected().catch((error: unknown) => {
+                console.error("Failed to start game:", error);
+            });
         }
     }
 

--- a/tests/unit/components/LineDrawer.test.ts
+++ b/tests/unit/components/LineDrawer.test.ts
@@ -315,4 +315,56 @@ describe("LineDrawer", () => {
             expect((lineDrawer as any).startPoint).toBeNull();
         });
     });
+
+    describe("segment lifetime", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("should destroy and forget all segments after lineDrawTime", () => {
+            // 交差しない直線を描く(ループ判定を発生させない)
+            const move = (x: number, y: number) =>
+                (lineDrawer as any).onPointerMove(x, y);
+            move(100, 100);
+            move(120, 100);
+            move(140, 100);
+            move(160, 100);
+
+            const segments = [...(lineDrawer as any).segments];
+            expect(segments).toHaveLength(3);
+
+            vi.advanceTimersByTime(lineDrawer.originalLineDrawTime + 100);
+
+            // 寿命切れのセグメントは配列からも消え、Graphicsも破棄される
+            expect((lineDrawer as any).segments).toHaveLength(0);
+            segments.forEach((segment) => {
+                expect(segment.graphics.destroy).toHaveBeenCalled();
+            });
+        });
+
+        it("should not detect a loop against expired (invisible) segments", () => {
+            const move = (x: number, y: number) =>
+                (lineDrawer as any).onPointerMove(x, y);
+            const loopCompleted = vi.fn();
+            lineDrawer.on("loopAreaCompleted", loopCompleted);
+
+            // ストロークA: 縦線
+            move(200, 100);
+            move(200, 200);
+
+            // 寿命切れを待つ(線は画面から消えている)
+            vi.advanceTimersByTime(lineDrawer.originalLineDrawTime + 100);
+
+            // ストロークB: ストロークAの跡地を横切る横線
+            move(150, 150);
+            move(250, 150);
+
+            // 見えない線分と交差してもループ完成にしてはいけない
+            expect(loopCompleted).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/unit/components/StageInformation.test.ts
+++ b/tests/unit/components/StageInformation.test.ts
@@ -80,6 +80,22 @@ describe("StageInformation", () => {
             si.next(); // level 12: +2 every overflow level
             expect(si.needCount).toBe(overflowNeedCount + 2);
         });
+
+        it("should not mutate the shared config across game runs", () => {
+            // 1周目でレベル上限を超えても、2周目(新インスタンス)の同レベルの
+            // 必要数が変わってはいけない
+            const firstRun = new StageInformation();
+            while (firstRun.level < 11) {
+                firstRun.next();
+            }
+            const firstRunNeedCount = firstRun.needCount;
+
+            const secondRun = new StageInformation();
+            while (secondRun.level < 11) {
+                secondRun.next();
+            }
+            expect(secondRun.needCount).toBe(firstRunNeedCount);
+        });
     });
 
     describe("calcScore", () => {


### PR DESCRIPTION
## 概要 / Summary

リファクタリングPhase 2: アニメーションループのリーク、見えない線分がループ判定に参加するバグ、非同期エラーの握りつぶしを修正します。
Refactoring Phase 2: fix animation-loop leaks, invisible segments joining loop detection, and swallowed async errors.

close: #25
close: #26
close: #29

**Note**: base は #38 (`feature/type-safety-phase1`) に積んだスタックPRです。#38 を先にマージすると base が自動的に main になります。
This PR is stacked on #38; merge #38 first and the base will retarget to main automatically.

#31 の残項目(ObjectPooling、空間分割、InputManager/AssetManager分離、immutable state等)は現在のゲーム規模では過剰設計と判断し見送りました。#31 にコメントの上 close を推奨します。
The remaining #31 items (object pooling, spatial partitioning, manager-layer extraction, immutable state) look like over-engineering at this scale — recommend closing #31 with a comment.

## 変更内容 / Changes

- **LineDrawer**: 寿命切れセグメントを配列からも除去して破棄。**画面から消えた「ゴースト線分」が新しいストロークと交差してループ誤発動するバグを修正** (#26)。削除イテレーションのスキップバグも修正
  Expired segments are removed from the array and destroyed, so invisible strokes can no longer trigger phantom loops (#26)
- **BaseCaptureableObject / Butterfly / LineDrawer**: requestAnimationFrame ループに破棄済みガードを追加、`delete()` の二重呼び出し防止、フェードインの alpha クランプ (#25)
- **BaseState**: fadeIn/fadeOut/slideY の Ticker が、対象コンテナがアニメーション中に破棄された場合に自壊するように (#25)
- **Butterfly**: 上端境界条件のバグ修正 (`yDiretion < top` → `< 0`) (#26)
- **StageInformation**: 最終ステージ超過時の needCount 加算が共有 JSON config を破壊的変更していた問題を修正(レベルごとに決定的、周回しても安定)
- **game.ts**: アセット読み込み失敗時にユーザーに見えるメッセージを表示 (#29)
- **GameStateManager**: currentState を null 安全に、async な onEnter の失敗をログ (#29)
- **StartState / RuleState**: `void` で握りつぶしていた非同期呼び出しにエラーログを追加 (#29)
- **tooling**: `.claude/worktrees` を eslint / git の ignore に追加

## 検証 / Verification

- 回帰テスト3件を修正前に作成し RED を確認してから修正(TDD) / 3 regression tests written first (red on the old code)
- ユニット/統合テスト 277件 全て成功 / All 277 tests pass
- 実ブラウザ検証(Playwright): ①消えた線分の跡地を横切ってもループが誤発動しないこと ②正規のループ描画でゲームが開始することを確認。ページエラーなし
  Verified in a real browser: no phantom loop on expired strokes, and normal loop-draw still starts the game; no page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)