### PR TITLE
Add personal high score records with localStorage

### DIFF
--- a/src/scripts/scenes/ResultState.ts
+++ b/src/scripts/scenes/ResultState.ts
@@ -10,6 +10,7 @@ import { StateBase } from "./BaseState";
 import { Button } from "../components/Button";
 import { LineDrawer } from "../components/LineDrawer";
 import { AudioManager } from "../utils/AudioManager";
+import { saveResult } from "../utils/ScoreStorage";
 
 export class ResultState extends StateBase {
     private stageInfo: StageInformation;
@@ -18,6 +19,7 @@ export class ResultState extends StateBase {
     private stickySprite: PIXI.Sprite;
     private backToStartButton!: Button;
     private nextMessage!: Message;
+    private recordMessage?: Message;
     private lineDrawer!: LineDrawer;
     private isGotBonusButterfly: boolean = false;
 
@@ -110,6 +112,29 @@ export class ResultState extends StateBase {
             );
         } else {
             // ゲームオーバーの場合はスタート画面に戻る
+
+            // 個人記録(ハイスコア・前回スコア)をlocalStorageに保存し、結果を表示する
+            const { isNewRecord, previousBest } = saveResult(
+                this.stageInfo.totalScore,
+            );
+            if (isNewRecord) {
+                this.recordMessage = new Message("New Record!", 24);
+            } else if (previousBest !== null) {
+                this.recordMessage = new Message(
+                    `Best: ${Utility.formatNumberWithCommas(previousBest)}`,
+                    20,
+                );
+            }
+            if (this.recordMessage) {
+                this.recordMessage.anchor.set(0.5);
+                this.recordMessage.x = this.manager.app.screen.width / 2;
+                this.recordMessage.y =
+                    this.manager.app.screen.height / 2 +
+                    this.manager.app.screen.height * 0.1;
+                this.container.addChild(this.recordMessage);
+                this.recordMessage.show();
+            }
+
             this.lineDrawer = new LineDrawer(this.manager.app);
 
             this.lineDrawer.on(
@@ -274,6 +299,9 @@ export class ResultState extends StateBase {
                 this.fadeOut(this.backToStartButton),
                 this.fadeOut(this.nextMessage),
                 this.fadeOut(this.stickySprite),
+                ...(this.recordMessage
+                    ? [this.fadeOut(this.recordMessage)]
+                    : []),
             ]);
             const startState = new StartState(this.manager);
             this.manager.setState(startState);

--- a/src/scripts/utils/ScoreStorage.ts
+++ b/src/scripts/utils/ScoreStorage.ts
@@ -1,0 +1,62 @@
+/**
+ * localStorageを使った個人記録(ハイスコア・前回スコア)の保存/読み込みを行うユーティリティ。
+ *
+ * プライベートブラウジング等でlocalStorageが利用できない/例外を投げる環境でも
+ * ゲームが止まらないよう、すべてのlocalStorageアクセスをtry/catchで包んでいる。
+ * 外部送信は一切行わず、localStorageのみを利用する。
+ */
+
+const HIGH_SCORE_KEY = "loopgame.highScore";
+const LAST_SCORE_KEY = "loopgame.lastScore";
+
+export interface SaveResultOutcome {
+    isNewRecord: boolean;
+    previousBest: number | null;
+}
+
+function parseScore(raw: string | null): number | null {
+    if (raw === null) {
+        return null;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readScore(key: string): number | null {
+    try {
+        return parseScore(localStorage.getItem(key));
+    } catch {
+        return null;
+    }
+}
+
+/** 保存されているハイスコアを取得する。未保存/取得不可の場合はnull。 */
+export function getHighScore(): number | null {
+    return readScore(HIGH_SCORE_KEY);
+}
+
+/** 保存されている前回スコアを取得する。未保存/取得不可の場合はnull。 */
+export function getLastScore(): number | null {
+    return readScore(LAST_SCORE_KEY);
+}
+
+/**
+ * 今回のスコアを保存し、ハイスコア更新の有無を判定して返す。
+ * localStorageへのアクセスが例外を投げる場合は保存をスキップし、
+ * { isNewRecord: false, previousBest: null } を返す。
+ */
+export function saveResult(totalScore: number): SaveResultOutcome {
+    try {
+        const previousBest = parseScore(localStorage.getItem(HIGH_SCORE_KEY));
+        const isNewRecord = previousBest === null || totalScore > previousBest;
+
+        localStorage.setItem(LAST_SCORE_KEY, String(totalScore));
+        if (isNewRecord) {
+            localStorage.setItem(HIGH_SCORE_KEY, String(totalScore));
+        }
+
+        return { isNewRecord, previousBest };
+    } catch {
+        return { isNewRecord: false, previousBest: null };
+    }
+}

--- a/tests/unit/utils/ScoreStorage.test.ts
+++ b/tests/unit/utils/ScoreStorage.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+    getHighScore,
+    getLastScore,
+    saveResult,
+} from "../../../src/scripts/utils/ScoreStorage";
+
+const HIGH_SCORE_KEY = "loopgame.highScore";
+const LAST_SCORE_KEY = "loopgame.lastScore";
+
+describe("ScoreStorage", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe("getHighScore()", () => {
+        it("returns null when no high score has been saved", () => {
+            expect(getHighScore()).toBeNull();
+        });
+
+        it("returns the stored high score as a number", () => {
+            localStorage.setItem(HIGH_SCORE_KEY, "1200");
+            expect(getHighScore()).toBe(1200);
+        });
+
+        it("returns null when the stored value is not a valid number", () => {
+            localStorage.setItem(HIGH_SCORE_KEY, "not-a-number");
+            expect(getHighScore()).toBeNull();
+        });
+
+        it("returns null when localStorage access throws", () => {
+            const spy = vi
+                .spyOn(Storage.prototype, "getItem")
+                .mockImplementation(() => {
+                    throw new Error("blocked (private mode)");
+                });
+
+            expect(getHighScore()).toBeNull();
+
+            spy.mockRestore();
+        });
+    });
+
+    describe("getLastScore()", () => {
+        it("returns null when no last score has been saved", () => {
+            expect(getLastScore()).toBeNull();
+        });
+
+        it("returns the stored last score as a number", () => {
+            localStorage.setItem(LAST_SCORE_KEY, "500");
+            expect(getLastScore()).toBe(500);
+        });
+
+        it("returns null when localStorage access throws", () => {
+            const spy = vi
+                .spyOn(Storage.prototype, "getItem")
+                .mockImplementation(() => {
+                    throw new Error("blocked (private mode)");
+                });
+
+            expect(getLastScore()).toBeNull();
+
+            spy.mockRestore();
+        });
+    });
+
+    describe("saveResult()", () => {
+        it("treats the first ever score as a new record with no previous best", () => {
+            const result = saveResult(1000);
+
+            expect(result).toEqual({ isNewRecord: true, previousBest: null });
+            expect(getHighScore()).toBe(1000);
+            expect(getLastScore()).toBe(1000);
+        });
+
+        it("reports a new record and updates the high score when beaten", () => {
+            saveResult(1000);
+
+            const result = saveResult(1500);
+
+            expect(result).toEqual({ isNewRecord: true, previousBest: 1000 });
+            expect(getHighScore()).toBe(1500);
+            expect(getLastScore()).toBe(1500);
+        });
+
+        it("does not overwrite the high score when the new score is lower", () => {
+            saveResult(1000);
+
+            const result = saveResult(400);
+
+            expect(result).toEqual({
+                isNewRecord: false,
+                previousBest: 1000,
+            });
+            expect(getHighScore()).toBe(1000);
+            expect(getLastScore()).toBe(400);
+        });
+
+        it("does not treat an equal score as a new record", () => {
+            saveResult(1000);
+
+            const result = saveResult(1000);
+
+            expect(result).toEqual({
+                isNewRecord: false,
+                previousBest: 1000,
+            });
+            expect(getHighScore()).toBe(1000);
+        });
+
+        it("always updates the last score, even when it is not a record", () => {
+            saveResult(1000);
+            saveResult(300);
+
+            expect(getLastScore()).toBe(300);
+            expect(getHighScore()).toBe(1000);
+        });
+
+        it("returns a not-new-record result and skips saving when localStorage throws", () => {
+            const getSpy = vi
+                .spyOn(Storage.prototype, "getItem")
+                .mockImplementation(() => {
+                    throw new Error("blocked (private mode)");
+                });
+            const setSpy = vi
+                .spyOn(Storage.prototype, "setItem")
+                .mockImplementation(() => {
+                    throw new Error("blocked (private mode)");
+                });
+
+            const result = saveResult(1000);
+
+            expect(result).toEqual({ isNewRecord: false, previousBest: null });
+
+            getSpy.mockRestore();
+            setSpy.mockRestore();
+        });
+
+        it("does not partially save when setItem throws after a successful read", () => {
+            const setSpy = vi
+                .spyOn(Storage.prototype, "setItem")
+                .mockImplementation(() => {
+                    throw new Error("quota exceeded");
+                });
+
+            expect(() => saveResult(1000)).not.toThrow();
+
+            setSpy.mockRestore();
+
+            // Nothing should have been persisted because the write failed.
+            expect(getHighScore()).toBeNull();
+            expect(getLastScore()).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## 概要 / Summary

localStorageで個人記録(ハイスコア・前回スコア)を保持し、ゲームオーバー時のリザルト画面に表示します。
Persist personal best / last scores in localStorage and show them on the final result screen.

close: #8

## 変更内容 / Changes

- 新規 `ScoreStorage.ts`: `loopgame.highScore` / `loopgame.lastScore` キーでの保存・読込。**全localStorageアクセスをtry/catchで包み、プライベートモード等でも例外でゲームが止まらない**(その場合は記録なしで動作継続)。壊れた保存値は `Number.isFinite` で弾いて null 扱い
  New `ScoreStorage.ts` util: exception-safe localStorage wrapper; corrupt values are rejected safely
- `ResultState`: ゲームオーバー分岐(最終スコア確定後)で `saveResult()` を呼び、ハイスコア更新時は「New Record!」、それ以外は「Best: N」を既存の Message クラスで表示。画面遷移時のフェードアウトにも組込
  Save on the game-over branch and show "New Record!" / "Best: N" using the existing Message component
- テスト14件追加(TDD: 実装前にRED確認。localStorage例外環境・初回・同値スコアなどの異常系含む)

## プライバシー / Privacy

- 保存はゲームスコア(数値)のみ。**外部送信・Cookie・トラッキングは一切なし**(端末内localStorageのみ)。ブラウザの閲覧データ削除で消えます
- Scores only, stored locally in the browser; no network transmission, cookies, or tracking

## 検証 / Verification

- ユニット/統合テスト 279件 全て成功 / All 279 tests pass
- 記録タイミングをコードレビューで確認: `calcScore()` は `GameplayState.endGame()` で ResultState 生成前に実行されるため保存値は最終スコア。ゲーム終了は isClear=false の一経路のみで二重保存なし(ボーナスステージは isClear=true のため対象外)

実装: coderエージェント(Sonnet) / レビュー: Fable
Implemented by the coder agent (Sonnet), reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)