### PR TITLE
Add mute button, tap-to-start gate, and unified pause button

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,19 @@
             <div id="loading">
                 <i class="fa fa-spinner fa-spin fa-5x fa-fw"></i>Loading...
             </div>
-            <div id="mainCanvas"></div>
+            <div id="mainCanvas">
+                <div id="tapToStart" class="hidden">
+                    <span>Tap to Start</span>
+                </div>
+                <div id="gameUi">
+                    <button id="muteButton" aria-label="mute">
+                        <i class="fa fa-volume-up"></i>
+                    </button>
+                    <button id="pauseButton" class="hidden" aria-label="pause">
+                        <i class="fa fa-pause"></i>
+                    </button>
+                </div>
+            </div>
             <div id="caption">
                 このゲームは、提供が終了されたshockwaveのゲーム「Loop」を再現したものです。<br />This
                 is a recreation of the game 'Loop', originally made with

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -66,3 +66,66 @@ details {
 a {
     color: #00b7ff;
 }
+
+/* --- in-game UI (mute / pause) --- */
+#mainCanvas {
+    position: relative;
+}
+
+#gameUi {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    gap: 8px;
+    z-index: 10;
+}
+
+#gameUi button {
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background-color: rgba(36, 36, 36, 0.55);
+    color: #ffffff;
+    font-size: 18px;
+    cursor: pointer;
+}
+
+#gameUi button:hover {
+    background-color: rgba(36, 36, 36, 0.8);
+}
+
+#gameUi button.hidden,
+#tapToStart.hidden {
+    display: none;
+}
+
+/* --- Click / Tap to Start gate --- */
+#tapToStart {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.55);
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: 0.1em;
+    z-index: 20;
+    cursor: pointer;
+}
+
+#tapToStart span {
+    animation: tapToStartPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes tapToStartPulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.4;
+    }
+}

--- a/src/scripts/game.ts
+++ b/src/scripts/game.ts
@@ -1,6 +1,7 @@
 import * as PIXI from "pixi.js";
 import { imageSrcs, seSrcs } from "./utils/Const";
 import { AudioManager } from "./utils/AudioManager";
+import { getMuted, setMuted } from "./utils/SettingsStorage";
 import { GameStateManager } from "./scenes/GameStateManager";
 import { StartState } from "./scenes/StartState";
 import { ResponsiveCanvas } from "./utils/ResponsiveCanvas";
@@ -66,16 +67,9 @@ window.addEventListener("load", async () => {
         antialias: true,
     });
 
-    // ブラウザの自動再生制限: 最初の操作でオーディオを解禁する
-    window.addEventListener(
-        "pointerdown",
-        () => {
-            AudioManager.shared.unlock();
-        },
-        { once: true },
-    );
     // SEの読み込みは起動をブロックしない
     void AudioManager.shared.loadSe(seSrcs);
+    setupMuteButton();
 
     const mainCanvas = document.getElementById("mainCanvas");
     if (mainCanvas) {
@@ -102,7 +96,9 @@ window.addEventListener("load", async () => {
 
     try {
         await PIXI.Assets.load(imageSrcs);
+        // タイトル画面を裏で起動してからゲートを被せる(操作はゲートが遮る)
         setUp();
+        await waitForTapToStart();
     } catch (error) {
         console.error("Failed to load game assets:", error);
         const loading = document.getElementById("loading");
@@ -121,6 +117,55 @@ document.addEventListener("DOMContentLoaded", function () {
         img.src = baseUrl + img.getAttribute("src");
     });
 });
+
+/**
+ * Click / Tap to Start ゲート。
+ * ユーザー操作を1回保証することで、ブラウザの自動再生制限を確実に解除する
+ * (このゲームはマウス移動だけで遊べるため、これがないと無音のままになり得る)
+ */
+function waitForTapToStart(): Promise<void> {
+    return new Promise((resolve) => {
+        const loading = document.getElementById("loading");
+        if (loading) {
+            loading.style.display = "none";
+        }
+        const gate = document.getElementById("tapToStart");
+        if (!gate) {
+            resolve();
+            return;
+        }
+        gate.classList.remove("hidden");
+        gate.addEventListener(
+            "pointerdown",
+            () => {
+                AudioManager.shared.unlock();
+                gate.classList.add("hidden");
+                resolve();
+            },
+            { once: true },
+        );
+    });
+}
+
+function setupMuteButton(): void {
+    const button = document.getElementById("muteButton");
+    if (!button) {
+        return;
+    }
+    const icon = button.querySelector("i");
+    const apply = (muted: boolean) => {
+        AudioManager.shared.setMuted(muted);
+        if (icon) {
+            icon.className = muted ? "fa fa-volume-off" : "fa fa-volume-up";
+        }
+    };
+    apply(getMuted());
+    button.addEventListener("click", () => {
+        const muted = !AudioManager.shared.isMuted();
+        setMuted(muted);
+        apply(muted);
+    });
+}
 
 function setUp() {
     // app.init()完了後なのでcanvasは必ず存在する

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -36,7 +36,7 @@ export class GameplayState extends StateBase {
     flowers: HelpFlower[] = [];
     private stageInfo: StageInformation;
     private readonly helpFlowersTiming: number[] = [];
-    pointerDownHandler: (event: PIXI.FederatedPointerEvent) => void;
+    private pauseHandler: () => void;
     private gatherPointMap: Map<number, PIXI.Point> = new Map();
     private gatherDistance: number = 0;
     private fontColor: number = 0x000000;
@@ -157,24 +157,30 @@ export class GameplayState extends StateBase {
         // Frame
         this.addFrameGraphic();
 
-        // イベントリスナー：クリックしたら一時停止
-        this.pointerDownHandler = () => {
-            if (this.isFinish) return;
-
-            this.isRunning = !this.isRunning;
-            this.lineDrawer.clearAllSegments();
-            this.butterflies.forEach((butterfly) => {
-                butterfly.isFlying =
-                    this.isRunning && this.freezeElapsedTime <= 0;
-            });
-            if (!this.isRunning) {
-                this.showActionMessage("Pause");
-            } else {
-                this.actionMessage.alpha = 0;
-            }
+        // 一時停止はUI上のボタンで行う(タッチ操作の描画と衝突しないように、
+        // ステージ全体クリックでの一時停止は廃止 #41)
+        this.pauseHandler = () => {
+            this.togglePause();
         };
+    }
 
-        app.stage.addEventListener("pointerdown", this.pointerDownHandler);
+    private togglePause(): void {
+        if (this.isFinish) return;
+
+        this.isRunning = !this.isRunning;
+        this.lineDrawer.clearAllSegments();
+        this.butterflies.forEach((butterfly) => {
+            butterfly.isFlying = this.isRunning && this.freezeElapsedTime <= 0;
+        });
+        const icon = document.querySelector("#pauseButton i");
+        if (icon) {
+            icon.className = this.isRunning ? "fa fa-pause" : "fa fa-play";
+        }
+        if (!this.isRunning) {
+            this.showActionMessage("Pause");
+        } else {
+            this.actionMessage.alpha = 0;
+        }
     }
 
     private setupForHelpObject() {
@@ -250,6 +256,12 @@ export class GameplayState extends StateBase {
     }
 
     async onEnter(): Promise<void> {
+        const pauseButton = document.getElementById("pauseButton");
+        if (pauseButton) {
+            pauseButton.classList.remove("hidden");
+            pauseButton.addEventListener("click", this.pauseHandler);
+        }
+
         this.isRunning = false;
         this.startMessage.alpha = 1;
         this.scoreMessage.alpha = 1;
@@ -397,11 +409,14 @@ export class GameplayState extends StateBase {
     }
 
     onExit(): void {
-        if (this.pointerDownHandler) {
-            this.manager.app.stage.removeEventListener(
-                "pointerdown",
-                this.pointerDownHandler,
-            );
+        const pauseButton = document.getElementById("pauseButton");
+        if (pauseButton) {
+            pauseButton.classList.add("hidden");
+            pauseButton.removeEventListener("click", this.pauseHandler);
+            const icon = pauseButton.querySelector("i");
+            if (icon) {
+                icon.className = "fa fa-pause";
+            }
         }
         this.manager.app.stage.removeChild(this.container);
         this.container.destroy();

--- a/src/scripts/utils/AudioManager.ts
+++ b/src/scripts/utils/AudioManager.ts
@@ -37,6 +37,7 @@ export class AudioManager {
     private currentBgmSrc: string | null = null;
     private pendingBgmSrc: string | null = null;
     private unlocked = false;
+    private muted = false;
 
     private ensureContext(): AudioContext | null {
         if (this.context) {
@@ -78,7 +79,7 @@ export class AudioManager {
     playSe(alias: string, options: { rate?: number } = {}): void {
         const ctx = this.context;
         const buffer = this.buffers.get(alias);
-        if (!ctx || !buffer || ctx.state !== "running") {
+        if (!ctx || !buffer || ctx.state !== "running" || this.muted) {
             return;
         }
         try {
@@ -106,6 +107,18 @@ export class AudioManager {
             return;
         }
         this.startBgmElement(src);
+    }
+
+    /** ミュートを切り替える。BGMは再生位置を保ったまま消音/復帰する */
+    setMuted(muted: boolean): void {
+        this.muted = muted;
+        if (this.bgmElement) {
+            this.bgmElement.muted = muted;
+        }
+    }
+
+    isMuted(): boolean {
+        return this.muted;
     }
 
     stopBgm(fadeMs: number = 600): void {
@@ -137,6 +150,7 @@ export class AudioManager {
         const el = new Audio(src);
         el.loop = true;
         el.volume = 0;
+        el.muted = this.muted;
         this.bgmElement = el;
         this.fadeElement(el, this.bgmVolume, 800);
         el.play().catch(() => {

--- a/src/scripts/utils/SettingsStorage.ts
+++ b/src/scripts/utils/SettingsStorage.ts
@@ -1,0 +1,22 @@
+/**
+ * ユーザー設定(ミュート等)のlocalStorage保存。
+ * ScoreStorageと同様、localStorageが使えない環境でも例外を投げない。
+ */
+
+const MUTED_KEY = "loopgame.muted";
+
+export function getMuted(): boolean {
+    try {
+        return localStorage.getItem(MUTED_KEY) === "true";
+    } catch {
+        return false;
+    }
+}
+
+export function setMuted(muted: boolean): void {
+    try {
+        localStorage.setItem(MUTED_KEY, String(muted));
+    } catch {
+        // 保存できない環境では設定は揮発する(ゲームは継続)
+    }
+}

--- a/tests/unit/utils/AudioManager.test.ts
+++ b/tests/unit/utils/AudioManager.test.ts
@@ -203,6 +203,49 @@ describe("AudioManager", () => {
         });
     });
 
+    describe("muted", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("should not play SE while muted", async () => {
+            await manager.loadSe([{ alias: "a", src: "/a.m4a" }]);
+            manager.unlock();
+            manager.setMuted(true);
+            manager.playSe("a");
+            expect(MockAudioContext.instances[0].createdSources).toHaveLength(
+                0,
+            );
+        });
+
+        it("should mute and unmute the playing BGM element", () => {
+            manager.unlock();
+            manager.playBgm("/bgm/title.m4a");
+            const el = MockAudioElement.instances[0] as unknown as {
+                muted?: boolean;
+            };
+            manager.setMuted(true);
+            expect(el.muted).toBe(true);
+            manager.setMuted(false);
+            expect(el.muted).toBe(false);
+        });
+
+        it("should start new BGM muted while muted, and unmute later", () => {
+            manager.unlock();
+            manager.setMuted(true);
+            manager.playBgm("/bgm/stage.m4a");
+            const el = MockAudioElement.instances[0] as unknown as {
+                muted?: boolean;
+            };
+            expect(el.muted).toBe(true);
+            manager.setMuted(false);
+            expect(el.muted).toBe(false);
+        });
+    });
+
     describe("unlock", () => {
         it("should resume a suspended context", async () => {
             await manager.loadSe([{ alias: "a", src: "/a.m4a" }]);

--- a/tests/unit/utils/SettingsStorage.test.ts
+++ b/tests/unit/utils/SettingsStorage.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getMuted, setMuted } from "../../../src/scripts/utils/SettingsStorage";
+
+describe("SettingsStorage", () => {
+    let store: Record<string, string>;
+
+    beforeEach(() => {
+        store = {};
+        vi.stubGlobal("localStorage", {
+            getItem: vi.fn((key: string) => store[key] ?? null),
+            setItem: vi.fn((key: string, value: string) => {
+                store[key] = value;
+            }),
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("should default to unmuted", () => {
+        expect(getMuted()).toBe(false);
+    });
+
+    it("should persist and restore the muted flag", () => {
+        setMuted(true);
+        expect(getMuted()).toBe(true);
+        setMuted(false);
+        expect(getMuted()).toBe(false);
+    });
+
+    it("should use a namespaced key", () => {
+        setMuted(true);
+        expect(Object.keys(store)).toEqual(["loopgame.muted"]);
+    });
+
+    it("should not throw when localStorage is unavailable", () => {
+        vi.stubGlobal("localStorage", {
+            getItem: vi.fn(() => {
+                throw new Error("denied");
+            }),
+            setItem: vi.fn(() => {
+                throw new Error("denied");
+            }),
+        });
+        expect(getMuted()).toBe(false);
+        expect(() => setMuted(true)).not.toThrow();
+    });
+});


### PR DESCRIPTION
## 概要 / Summary

音とモバイル操作に関するUX改修3点セットです。
Three UX improvements around audio and input.

close: #45
close: #46
close: #41

## 変更内容 / Changes

### 🔊 ミュートボタン (#45)
- 画面右上に常時表示のスピーカーボタン(Font Awesome、全シーン共通のDOM要素)
- localStorageに永続化(`SettingsStorage`、例外安全)。リロード後も維持
- BGMは再生位置を保ったまま消音/復帰(ミュート中の曲切替も追従)

### 👆 Tap to Start ゲート (#46)
- アセット読込後、タイトル画面の上に半透明の「Tap to Start」を表示
- このゲームはマウス移動だけで遊べるため、従来はクリックしないと音が一切解禁されなかった。ゲートで**1操作を保証**し、確実に音が出るように
- モバイルのタッチ解禁も同時に解決

### ⏸ 一時停止ボタン (#41)
- **「画面のどこでもクリックで一時停止」を廃止** — タッチ操作では線を引くたびに一時停止が発動してしまうため
- ゲームプレイ中のみ表示される⏸/▶ボタンに統一(デスクトップも同じ挙動にして誤爆も解消)

## 検証 / Verification

- 全310テスト成功(SettingsStorage・ミュート挙動のユニットテストをTDDで追加)
- 実Chromeで確認: ゲート表示→クリックで解除・タイトルBGM開始 / ミュート切替とリロード後の永続 / 一時停止・再開とアイコン切替 / コンソールエラーなし

## スクリーンショット / Screenshot

タイトル画面の上に表示されるゲート(クリックで消えて音が解禁されます)

🤖 Generated with [Claude Code](https://claude.com/claude-code)