### PR TITLE
UX follow-up: fix Android audio unlock and restore desktop click-to-pause

### DIFF
--- a/src/scripts/game.ts
+++ b/src/scripts/game.ts
@@ -135,8 +135,11 @@ function waitForTapToStart(): Promise<void> {
             return;
         }
         gate.classList.remove("hidden");
+        // 注意: タッチでは pointerdown 時点だと「ユーザー操作」として
+        // 認定されず音声を解禁できない(Android Chrome等)。click は
+        // touchend 後に発火し、マウス/タッチ両方で確実に操作認定される
         gate.addEventListener(
-            "pointerdown",
+            "click",
             () => {
                 AudioManager.shared.unlock();
                 gate.classList.add("hidden");
@@ -144,6 +147,12 @@ function waitForTapToStart(): Promise<void> {
             },
             { once: true },
         );
+        // 保険: 解禁に失敗した場合に備えて、以降のクリック/タップでも再試行する
+        const retryUnlock = () => {
+            AudioManager.shared.unlock();
+        };
+        document.addEventListener("click", retryUnlock);
+        document.addEventListener("touchend", retryUnlock);
     });
 }
 

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -2,6 +2,7 @@
 import * as PIXI from "pixi.js";
 import { GameStateManager } from "./GameStateManager";
 import { AudioManager } from "../utils/AudioManager";
+import { isMobileDevice } from "../utils/MobileDetection";
 import { LineDrawer } from "../components/LineDrawer";
 import { Sun } from "../components/Sun";
 import { ResultState } from "./ResultState";
@@ -37,6 +38,7 @@ export class GameplayState extends StateBase {
     private stageInfo: StageInformation;
     private readonly helpFlowersTiming: number[] = [];
     private pauseHandler: () => void;
+    private stagePauseHandler: (() => void) | null = null;
     private gatherPointMap: Map<number, PIXI.Point> = new Map();
     private gatherDistance: number = 0;
     private fontColor: number = 0x000000;
@@ -157,11 +159,19 @@ export class GameplayState extends StateBase {
         // Frame
         this.addFrameGraphic();
 
-        // 一時停止はUI上のボタンで行う(タッチ操作の描画と衝突しないように、
-        // ステージ全体クリックでの一時停止は廃止 #41)
+        // 一時停止ボタン用ハンドラ(全プラットフォーム共通)
         this.pauseHandler = () => {
             this.togglePause();
         };
+
+        // PCはステージクリックでも一時停止できる。タッチ端末では線を引く
+        // 操作と衝突するため無効 (#41)
+        if (!isMobileDevice()) {
+            this.stagePauseHandler = () => {
+                this.togglePause();
+            };
+            app.stage.addEventListener("pointerdown", this.stagePauseHandler);
+        }
     }
 
     private togglePause(): void {
@@ -409,6 +419,12 @@ export class GameplayState extends StateBase {
     }
 
     onExit(): void {
+        if (this.stagePauseHandler) {
+            this.manager.app.stage.removeEventListener(
+                "pointerdown",
+                this.stagePauseHandler,
+            );
+        }
         const pauseButton = document.getElementById("pauseButton");
         if (pauseButton) {
             pauseButton.classList.add("hidden");


### PR DESCRIPTION
## 概要 / Summary

PR #47 のマージ後にブランチへ積んでいた修正2件のフォローアップです(本番に未反映だったため、Androidの無音とPCのクリック一時停止廃止がそのまま残っていました)。

Two follow-up commits that landed on the branch after #47 was merged, so they never reached production.

## 変更内容 / Changes

1. **Android で音が出ない問題の修正** (#45, #46 関連)
   - タッチ端末では `pointerdown` が自動再生ポリシーの「ユーザー操作」として認定されない(認定は touchend / click 時点)ため、ゲートの解禁が空振りして無音のままだった
   - 解禁を `click` ベースに変更+以降のクリック/タップで再試行する保険つき
   - Pixel 7 横向きタッチエミュレーション(デフォルトポリシー)で「タップ → AudioContext running → タイトルBGM再生」を確認済み
   - On touch devices `pointerdown` does not grant user activation, so the once-only unlock was consumed silently. Unlock now happens on `click`, with a retry fallback.

2. **PCのクリック一時停止を復活** (#41)
   - PC(非タッチ)はステージクリックでも一時停止可能(従来挙動)。⏸ボタンも併用可
   - タッチ端末は線を引く操作と衝突するためボタンのみ
   - Desktop regains click-anywhere pause; touch stays button-only.

## 検証 / Verification

- 全310テスト成功 / All 310 tests pass
- ローカルでPCクリック一時停止の動作確認済み(ユーザー確認) / Desktop click-pause confirmed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)