### PR TITLE
Widen the game field to 1150x650

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ All game assets are defined in `Const.ts` with BASE_URL prefix for deployment fl
 
 On mobile devices (user-agent detection in `MobileDetection.ts`), the game boots with a responsive canvas instead of the fixed 850x650 desktop size:
 
--   `ResponsiveCanvas`: fits the canvas to the viewport keeping the 850:650 aspect ratio and scales the PIXI stage accordingly (base resolution 850x650)
+-   `ResponsiveCanvas`: fits the canvas to the viewport keeping the game's aspect ratio (design resolution 1150x650, defined as GAME_WIDTH/GAME_HEIGHT in Const.ts)
 -   `TouchHandler`: handles touch events on the canvas and prevents default scrolling during play
 -   `LandscapePrompt`: recommends landscape orientation
 -   `public/styles/mobile.css`: mobile layout overrides (applied via media query for narrow or short viewports)

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -28,12 +28,12 @@ body {
 #mainCanvas,
 details {
     width: 100%;
-    max-width: 850px; /* 必要に応じて調整 */
+    max-width: 1150px; /* ゲームの設計解像度(Const.GAME_WIDTH)に合わせる */
     text-align: center;
 }
 
 #loading {
-    width: 850px;
+    width: 1150px;
     height: 650px;
     display: flex;
     flex-direction: column;

--- a/src/scripts/game.ts
+++ b/src/scripts/game.ts
@@ -1,4 +1,5 @@
 import * as PIXI from "pixi.js";
+import * as Const from "./utils/Const";
 import { imageSrcs, seSrcs } from "./utils/Const";
 import { AudioManager } from "./utils/AudioManager";
 import { getMuted, setMuted } from "./utils/SettingsStorage";
@@ -75,10 +76,10 @@ window.addEventListener("load", async () => {
 
     // Always render at the design resolution; on mobile the canvas is
     // scaled down visually via CSS by ResponsiveCanvas, so game code can
-    // keep positioning against app.screen (850x650)
+    // keep positioning against app.screen
     await app.init({
-        width: 850,
-        height: 650,
+        width: Const.GAME_WIDTH,
+        height: Const.GAME_HEIGHT,
         backgroundColor: 0xffd700,
         antialias: true,
     });
@@ -95,9 +96,9 @@ window.addEventListener("load", async () => {
     if (isMobile) {
         responsiveCanvas = new ResponsiveCanvas(app, app.canvas, {
             scaleMode: "fit",
-            targetAspectRatio: 850 / 650,
-            baseWidth: 850,
-            baseHeight: 650,
+            targetAspectRatio: Const.GAME_WIDTH / Const.GAME_HEIGHT,
+            baseWidth: Const.GAME_WIDTH,
+            baseHeight: Const.GAME_HEIGHT,
         });
         responsiveCanvas.init();
 

--- a/src/scripts/utils/Const.ts
+++ b/src/scripts/utils/Const.ts
@@ -26,6 +26,10 @@ export const HELP_FLOWER_TYPES = [
     "long",
 ] as const;
 
+// ゲームの設計解像度(全レイアウトはapp.screen基準なのでここを変えれば全体が追従)
+export const GAME_WIDTH = 1150;
+export const GAME_HEIGHT = 650;
+
 export const LONG_LOOP_EFFECT_TIME_MS = 5000;
 export const GATHER_EFFECT_TIME_MS = 10000;
 export const FREEZE_EFFECT_TIME_MS = 3000;


### PR DESCRIPTION
## 概要 / Summary

設計解像度を850×650 → **1150×650(約16:9)** にワイド化します。PCは持て余していた横幅を活用し、スマホ横画面は左右の黒帯が大幅に減ってプレイエリアが拡大します。

Widen the design resolution to 1150x650 (~16:9): desktop uses its width, landscape phones get a much larger play area.

close: #42

**Note**: #49 (`fix/font-loading-race`) に積んだスタックPRです。マージ順: #49 → 本PR。
Stacked on #49; merge #49 first.

## 変更内容 / Changes

- `Const.GAME_WIDTH / GAME_HEIGHT` を新設し、解像度の定義を一元化(全シーンのレイアウトは `app.screen` 基準なので自動追従)
- game.ts の初期化・ResponsiveCanvas のアスペクト比・style.css の枠幅・CLAUDE.md を更新

## 検証 / Verification

- タイトル / How to play / ゲームプレイ / リザルトの全シーンでレイアウト崩れなし(実Chromeでスクリーンショット確認)、コンソールエラーなし
- 全310テスト成功

## 留意点 / Note

フィールドが約35%広くなる一方で線の寿命は同じため、**体感でやや難化**します。プレイしてみてキツければ、ステージ設定(蝶の数・needCount)や線の寿命(`originalLineDrawTime`)の調整を提案します。

## 関連 / Related

案B(fill+上下クロップ)は上下40%が不可視になり、見えない場所を蝶が飛ぶためこのゲームには不適と判断して見送りました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)