### PR TITLE
Visual effects: glowing special butterfly and sparkle showers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/pixi.js": "^5.0.0"
+        "@types/pixi.js": "^5.0.0",
+        "pixi-filters": "^6.1.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.53.1",
@@ -1383,6 +1384,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha512-r7K3NkJz3A95WkVVmjs0NcchhHstC2C/VIYNX4JC6tieviUNo774FFeOHjThr3Vw/WCeMP9kAT77MKbIRlO/4w==",
+      "license": "MIT"
     },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
@@ -5411,6 +5418,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pixi-filters": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/pixi-filters/-/pixi-filters-6.1.5.tgz",
+      "integrity": "sha512-Ewb/J+kxAbaNN+0/ATJbglAJG+skGJfh7BIDP3ILIDdD6wWk1p0pGa25pVf1T8hGBOQSUNVAmwwJBwkj+cyLLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/gradient-parser": "^0.1.2"
+      },
+      "peerDependencies": {
+        "pixi.js": ">=8.0.0-0"
+      }
+    },
     "node_modules/pixi.js": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.4.1.tgz",
@@ -8566,6 +8585,11 @@
         "@types/send": "*"
       }
     },
+    "@types/gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha512-r7K3NkJz3A95WkVVmjs0NcchhHstC2C/VIYNX4JC6tieviUNo774FFeOHjThr3Vw/WCeMP9kAT77MKbIRlO/4w=="
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -11508,6 +11532,14 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "pixi-filters": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/pixi-filters/-/pixi-filters-6.1.5.tgz",
+      "integrity": "sha512-Ewb/J+kxAbaNN+0/ATJbglAJG+skGJfh7BIDP3ILIDdD6wWk1p0pGa25pVf1T8hGBOQSUNVAmwwJBwkj+cyLLA==",
+      "requires": {
+        "@types/gradient-parser": "^0.1.2"
+      }
     },
     "pixi.js": {
       "version": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/Uhsmt/LoopGame#readme",
   "dependencies": {
-    "@types/pixi.js": "^5.0.0"
+    "@types/pixi.js": "^5.0.0",
+    "pixi-filters": "^6.1.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.1",

--- a/src/scripts/components/SparkleEmitter.ts
+++ b/src/scripts/components/SparkleEmitter.ts
@@ -116,6 +116,29 @@ export class SparkleEmitter extends PIXI.Container {
         }
     }
 
+    /**
+     * サンプラーが返す位置に1粒ずつ、舞い落ちるきらきらを撒く。
+     * ループで囲んだ領域全体に降らせる用途など、形状に沿った配置に使う
+     */
+    showerOver(
+        count: number,
+        sample: () => { x: number; y: number },
+        options: BurstOptions = {},
+    ): void {
+        for (let i = 0; i < count; i++) {
+            const p = sample();
+            this.spawn(p.x, p.y, {
+                vx: (Math.random() - 0.5) * 0.03,
+                vy: 0.02 + Math.random() * 0.04,
+                gravity: 0.00012,
+                lifeMs: (options.lifeMs ?? 1500) * (0.6 + Math.random() * 0.4),
+                scale: (options.scale ?? 1) * (0.5 + Math.random() * 0.6),
+                tints: options.tints,
+                baseAlpha: 0.75,
+            });
+        }
+    }
+
     /** 軌跡用に1粒だけこぼす(ボーナス蝶の尾など) */
     trail(x: number, y: number, options: BurstOptions = {}): void {
         this.spawn(

--- a/src/scripts/components/SparkleEmitter.ts
+++ b/src/scripts/components/SparkleEmitter.ts
@@ -9,6 +9,7 @@ interface Particle {
     lifeMs: number;
     maxLifeMs: number;
     baseScale: number;
+    baseAlpha: number;
 }
 
 export interface BurstOptions {
@@ -87,6 +88,34 @@ export class SparkleEmitter extends PIXI.Container {
         }
     }
 
+    /**
+     * 範囲内からきらきらを舞い降らせる(大量捕獲のお祝いなど)。
+     * 弾けるのではなく、淡くゆっくり落ちるイメージ
+     */
+    shower(
+        x: number,
+        y: number,
+        count: number,
+        options: BurstOptions = {},
+    ): void {
+        for (let i = 0; i < count; i++) {
+            this.spawn(
+                x + (Math.random() - 0.5) * 190,
+                y + (Math.random() - 0.5) * 80,
+                {
+                    vx: (Math.random() - 0.5) * 0.03,
+                    vy: 0.02 + Math.random() * 0.04,
+                    gravity: 0.00012,
+                    lifeMs:
+                        (options.lifeMs ?? 1500) * (0.6 + Math.random() * 0.4),
+                    scale: (options.scale ?? 1) * (0.5 + Math.random() * 0.6),
+                    tints: options.tints,
+                    baseAlpha: 0.75,
+                },
+            );
+        }
+    }
+
     /** 軌跡用に1粒だけこぼす(ボーナス蝶の尾など) */
     trail(x: number, y: number, options: BurstOptions = {}): void {
         this.spawn(
@@ -113,6 +142,7 @@ export class SparkleEmitter extends PIXI.Container {
             lifeMs: number;
             scale: number;
             tints?: number[];
+            baseAlpha?: number;
         },
     ): void {
         // 上限を超える分は古いものから消す
@@ -133,6 +163,7 @@ export class SparkleEmitter extends PIXI.Container {
         sprite.scale.set(baseScale);
         this.addChild(sprite);
 
+        sprite.alpha = opts.baseAlpha ?? 1;
         this.particles.push({
             sprite,
             vx: opts.vx,
@@ -142,6 +173,7 @@ export class SparkleEmitter extends PIXI.Container {
             lifeMs: opts.lifeMs,
             maxLifeMs: opts.lifeMs,
             baseScale,
+            baseAlpha: opts.baseAlpha ?? 1,
         });
     }
 
@@ -159,7 +191,7 @@ export class SparkleEmitter extends PIXI.Container {
             p.sprite.y += p.vy * deltaMS;
             p.sprite.rotation += p.spin * deltaMS;
             const t = p.lifeMs / p.maxLifeMs;
-            p.sprite.alpha = t;
+            p.sprite.alpha = t * p.baseAlpha;
             p.sprite.scale.set(p.baseScale * (0.4 + 0.6 * t));
         }
     }

--- a/src/scripts/components/SparkleEmitter.ts
+++ b/src/scripts/components/SparkleEmitter.ts
@@ -1,0 +1,174 @@
+import * as PIXI from "pixi.js";
+
+interface Particle {
+    sprite: PIXI.Sprite;
+    vx: number;
+    vy: number;
+    spin: number;
+    gravity: number;
+    lifeMs: number;
+    maxLifeMs: number;
+    baseScale: number;
+}
+
+export interface BurstOptions {
+    lifeMs?: number;
+    speed?: number;
+    gravity?: number;
+    scale?: number;
+    tints?: number[];
+}
+
+/**
+ * 星型パーティクルのエミッタ。
+ *
+ * フィルタを使わずスプライト+加算合成だけで表現するため軽量
+ * (数百個程度なら普通のノートPCで問題なく動く)。
+ * パーティクル数はMAX_PARTICLESで上限を設け、暴走しないようにする。
+ */
+export class SparkleEmitter extends PIXI.Container {
+    private static readonly MAX_PARTICLES = 300;
+    private particles: Particle[] = [];
+    private texture: PIXI.Texture;
+
+    constructor(texture: PIXI.Texture) {
+        super();
+        this.texture = texture;
+    }
+
+    /**
+     * 星型テクスチャを生成する(起動時に1回だけ呼ぶ。画像素材不要)
+     */
+    static createStarTexture(renderer: PIXI.Renderer): PIXI.Texture {
+        const g = new PIXI.Graphics();
+        const outer = 7;
+        const inner = 2;
+        const points: number[] = [];
+        for (let i = 0; i < 8; i++) {
+            const r = i % 2 === 0 ? outer : inner;
+            const a = (i * Math.PI) / 4 - Math.PI / 2;
+            points.push(Math.cos(a) * r, Math.sin(a) * r);
+        }
+        g.poly(points);
+        g.fill(0xffffff);
+        const texture = renderer.generateTexture(g);
+        g.destroy();
+        return texture;
+    }
+
+    get particleCount(): number {
+        return this.particles.length;
+    }
+
+    /** 一点から星を放射状に散らす(捕獲エフェクトなど) */
+    burst(
+        x: number,
+        y: number,
+        count: number,
+        options: BurstOptions = {},
+    ): void {
+        const speed = options.speed ?? 0.18;
+        for (let i = 0; i < count; i++) {
+            const angle = Math.random() * Math.PI * 2;
+            const v = speed * (0.3 + Math.random() * 0.7);
+            this.spawn(x, y, {
+                vx: Math.cos(angle) * v,
+                vy: Math.sin(angle) * v - 0.05,
+                gravity: options.gravity ?? 0.00035,
+                lifeMs: options.lifeMs ?? 900,
+                scale: options.scale ?? 1,
+                tints: options.tints,
+            });
+        }
+    }
+
+    /** 軌跡用に1粒だけこぼす(ボーナス蝶の尾など) */
+    trail(x: number, y: number, options: BurstOptions = {}): void {
+        this.spawn(
+            x + (Math.random() - 0.5) * 14,
+            y + (Math.random() - 0.5) * 14,
+            {
+                vx: (Math.random() - 0.5) * 0.02,
+                vy: 0.015 + Math.random() * 0.02,
+                gravity: 0,
+                lifeMs: options.lifeMs ?? 850,
+                scale: (options.scale ?? 1) * (1.0 + Math.random() * 0.7),
+                tints: options.tints,
+            },
+        );
+    }
+
+    private spawn(
+        x: number,
+        y: number,
+        opts: {
+            vx: number;
+            vy: number;
+            gravity: number;
+            lifeMs: number;
+            scale: number;
+            tints?: number[];
+        },
+    ): void {
+        // 上限を超える分は古いものから消す
+        while (this.particles.length >= SparkleEmitter.MAX_PARTICLES) {
+            this.removeParticle(this.particles[0]);
+        }
+
+        const sprite = new PIXI.Sprite(this.texture);
+        sprite.anchor.set(0.5);
+        sprite.x = x;
+        sprite.y = y;
+        sprite.rotation = Math.random() * Math.PI;
+        // 加算合成は明るい背景で白飛びして見えなくなるため通常合成にする
+        sprite.blendMode = "normal";
+        const tints = opts.tints ?? [0xffb300, 0xff9500, 0xffd23e];
+        sprite.tint = tints[Math.floor(Math.random() * tints.length)];
+        const baseScale = opts.scale * (0.6 + Math.random() * 0.6);
+        sprite.scale.set(baseScale);
+        this.addChild(sprite);
+
+        this.particles.push({
+            sprite,
+            vx: opts.vx,
+            vy: opts.vy,
+            spin: (Math.random() - 0.5) * 0.008,
+            gravity: opts.gravity,
+            lifeMs: opts.lifeMs,
+            maxLifeMs: opts.lifeMs,
+            baseScale,
+        });
+    }
+
+    /** 毎フレーム呼ぶ(deltaMS: 経過ミリ秒) */
+    update(deltaMS: number): void {
+        for (let i = this.particles.length - 1; i >= 0; i--) {
+            const p = this.particles[i];
+            p.lifeMs -= deltaMS;
+            if (p.lifeMs <= 0) {
+                this.removeParticle(p);
+                continue;
+            }
+            p.vy += p.gravity * deltaMS;
+            p.sprite.x += p.vx * deltaMS;
+            p.sprite.y += p.vy * deltaMS;
+            p.sprite.rotation += p.spin * deltaMS;
+            const t = p.lifeMs / p.maxLifeMs;
+            p.sprite.alpha = t;
+            p.sprite.scale.set(p.baseScale * (0.4 + 0.6 * t));
+        }
+    }
+
+    private removeParticle(p: Particle): void {
+        this.particles = this.particles.filter((x) => x !== p);
+        this.removeChild(p.sprite);
+        p.sprite.destroy();
+    }
+
+    /** 全パーティクルを破棄する(シーン離脱時) */
+    clear(): void {
+        for (const p of [...this.particles]) {
+            this.removeParticle(p);
+        }
+    }
+}

--- a/src/scripts/components/SparkleEmitter.ts
+++ b/src/scripts/components/SparkleEmitter.ts
@@ -41,6 +41,11 @@ export class SparkleEmitter extends PIXI.Container {
      */
     static createStarTexture(renderer: PIXI.Renderer): PIXI.Texture {
         const g = new PIXI.Graphics();
+        // 柔らかいハロー(同心円のアルファ重ね)で発光レイヤーっぽく見せる
+        g.circle(0, 0, 12).fill({ color: 0xffffff, alpha: 0.1 });
+        g.circle(0, 0, 8).fill({ color: 0xffffff, alpha: 0.18 });
+        g.circle(0, 0, 5).fill({ color: 0xffffff, alpha: 0.3 });
+        // 中心の星
         const outer = 7;
         const inner = 2;
         const points: number[] = [];
@@ -122,7 +127,7 @@ export class SparkleEmitter extends PIXI.Container {
         sprite.rotation = Math.random() * Math.PI;
         // 加算合成は明るい背景で白飛びして見えなくなるため通常合成にする
         sprite.blendMode = "normal";
-        const tints = opts.tints ?? [0xffb300, 0xff9500, 0xffd23e];
+        const tints = opts.tints ?? [0xffffff, 0xfff6d8, 0xffe9a8];
         sprite.tint = tints[Math.floor(Math.random() * tints.length)];
         const baseScale = opts.scale * (0.6 + Math.random() * 0.6);
         sprite.scale.set(baseScale);

--- a/src/scripts/components/SparkleEmitter.ts
+++ b/src/scripts/components/SparkleEmitter.ts
@@ -103,14 +103,14 @@ export class SparkleEmitter extends PIXI.Container {
                 x + (Math.random() - 0.5) * 190,
                 y + (Math.random() - 0.5) * 80,
                 {
-                    vx: (Math.random() - 0.5) * 0.03,
-                    vy: 0.02 + Math.random() * 0.04,
-                    gravity: 0.00012,
+                    vx: (Math.random() - 0.5) * 0.02,
+                    vy: 0.012 + Math.random() * 0.022,
+                    gravity: 0.00007,
                     lifeMs:
                         (options.lifeMs ?? 1500) * (0.6 + Math.random() * 0.4),
                     scale: (options.scale ?? 1) * (0.5 + Math.random() * 0.6),
                     tints: options.tints,
-                    baseAlpha: 0.75,
+                    baseAlpha: 0.6,
                 },
             );
         }
@@ -128,13 +128,13 @@ export class SparkleEmitter extends PIXI.Container {
         for (let i = 0; i < count; i++) {
             const p = sample();
             this.spawn(p.x, p.y, {
-                vx: (Math.random() - 0.5) * 0.03,
-                vy: 0.02 + Math.random() * 0.04,
-                gravity: 0.00012,
+                vx: (Math.random() - 0.5) * 0.02,
+                vy: 0.012 + Math.random() * 0.022,
+                gravity: 0.00007,
                 lifeMs: (options.lifeMs ?? 1500) * (0.6 + Math.random() * 0.4),
                 scale: (options.scale ?? 1) * (0.5 + Math.random() * 0.6),
                 tints: options.tints,
-                baseAlpha: 0.75,
+                baseAlpha: 0.6,
             });
         }
     }

--- a/src/scripts/components/SpecialButterfly.ts
+++ b/src/scripts/components/SpecialButterfly.ts
@@ -14,8 +14,8 @@ export class SpecialButterfly extends Butterfly {
         this.glow = new GlowFilter({
             distance: 14,
             outerStrength: 2.5,
-            innerStrength: 0.6,
-            color: 0xffe066,
+            innerStrength: 0.9,
+            color: 0xfff0c8,
             quality: 0.3,
         });
         this.filters = [this.glow];

--- a/src/scripts/components/SpecialButterfly.ts
+++ b/src/scripts/components/SpecialButterfly.ts
@@ -1,40 +1,32 @@
 import * as PIXI from "pixi.js";
+import { GlowFilter } from "pixi-filters";
 import { Butterfly } from "./Butterfly";
 
 export class SpecialButterfly extends Butterfly {
-    private filterProgress: number = 0;
-    private effectSprite: PIXI.Sprite;
+    private glowProgress: number = 0;
+    private glow: GlowFilter;
     hitRate: number = 0.4;
 
     constructor(color: number, screenSize: { x: number; y: number }) {
         super("special", color, color, 1, screenSize);
 
-        this.effectSprite = PIXI.Sprite.from("stardust");
-        this.effectSprite.anchor.set(0.5);
-        this.effectSprite.scale.set(0.5);
-        this.effectSprite.alpha = 1;
-        this.effectSprite.blendMode = "add";
+        // 金色のグローを脈動させる(小さいスプライトへのフィルタなので軽量)
+        this.glow = new GlowFilter({
+            distance: 14,
+            outerStrength: 2.5,
+            innerStrength: 0.6,
+            color: 0xffe066,
+            quality: 0.3,
+        });
+        this.filters = [this.glow];
 
-        const effectMask = new PIXI.Graphics();
-        effectMask.circle(0, 0, (1.2 * this.sprite.width) / 2);
-        effectMask.fill(0x000000);
-        effectMask.alpha = 0.5;
-        this.addChildAt(effectMask, 0);
-        this.effectSprite.mask = effectMask;
-
-        this.addChildAt(this.effectSprite, 0);
-
-        this.sprite.blendMode = "luminosity";
         this.hitAreaSize = this.sprite.height / 3;
     }
 
     update(delta: number, lineSegments: PIXI.Point[]): void {
-        // effectSpriteを回転させる
-        this.effectSprite.rotation += 0.001 * delta;
-
-        // alphaを0.5~1.0で変化させる
-        this.effectSprite.alpha = 0.7 + 0.3 * Math.sin(this.filterProgress);
-        this.filterProgress += 0.001 * delta;
+        // グローの強さをふわ〜っと脈動させる
+        this.glowProgress += 0.003 * delta;
+        this.glow.outerStrength = 2.2 + 1.5 * Math.sin(this.glowProgress);
 
         super.update(delta, lineSegments);
     }

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -181,6 +181,40 @@ export class GameplayState extends StateBase {
         }
     }
 
+    private showerOverLoopArea(
+        butterflies: Butterfly[],
+        loopArea?: PIXI.Graphics,
+    ): void {
+        const fallbackX =
+            butterflies.reduce((sum, b) => sum + b.x - b.width / 2, 0) /
+            butterflies.length;
+        const fallbackY =
+            butterflies.reduce((sum, b) => sum + b.y - b.height / 2, 0) /
+            butterflies.length;
+        try {
+            if (!loopArea) throw new Error("no loop area");
+            const bounds = loopArea.getBounds();
+            // 領域の広さに応じて粒数を増やす(45〜90)
+            const count = Math.min(
+                90,
+                45 + Math.floor((bounds.width * bounds.height) / 8000),
+            );
+            this.sparkles.showerOver(count, () => {
+                // 矩形サンプリング+領域内判定(外れたら中心へフォールバック)
+                for (let i = 0; i < 8; i++) {
+                    const x = bounds.x + Math.random() * bounds.width;
+                    const y = bounds.y + Math.random() * bounds.height;
+                    if (loopArea.containsPoint({ x, y })) {
+                        return { x, y };
+                    }
+                }
+                return { x: fallbackX, y: fallbackY };
+            });
+        } catch {
+            this.sparkles.shower(fallbackX, fallbackY, 45);
+        }
+    }
+
     private createStarTexture(): PIXI.Texture {
         try {
             return SparkleEmitter.createStarTexture(this.manager.app.renderer);
@@ -576,7 +610,7 @@ export class GameplayState extends StateBase {
             }
         } else if (butterfliesInLoopArea.length >= 2) {
             if (this.isSuccessLoop(butterfliesInLoopArea)) {
-                this.captureButterflies(butterfliesInLoopArea);
+                this.captureButterflies(butterfliesInLoopArea, loopArea);
                 this.captureFlowers(flowersInLoopArea);
             } else {
                 this.stagePoint -= 20;
@@ -586,20 +620,17 @@ export class GameplayState extends StateBase {
         }
     }
 
-    private captureButterflies(butterflies: Butterfly[]): void {
+    private captureButterflies(
+        butterflies: Butterfly[],
+        loopArea?: PIXI.Graphics,
+    ): void {
         AudioManager.shared.playSe(
             butterflies.length >= 10 ? "se_capture_many" : "se_capture",
         );
 
-        // 10匹以上の大量捕獲時だけ、淡いきらきらを舞い降らせる
+        // 10匹以上の大量捕獲時だけ、囲んだ領域全体に淡いきらきらを降らせる
         if (butterflies.length >= 10) {
-            const centerX =
-                butterflies.reduce((sum, b) => sum + b.x - b.width / 2, 0) /
-                butterflies.length;
-            const centerY =
-                butterflies.reduce((sum, b) => sum + b.y - b.height / 2, 0) /
-                butterflies.length;
-            this.sparkles.shower(centerX, centerY, 45);
+            this.showerOverLoopArea(butterflies, loopArea);
         }
 
         this.caputuredButterflies.push(...butterflies);

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -590,6 +590,26 @@ export class GameplayState extends StateBase {
         AudioManager.shared.playSe(
             butterflies.length >= 10 ? "se_capture_many" : "se_capture",
         );
+
+        // 捕まえた蝶たちの中心からキラキラを散らす(多いほど盛大に)
+        const centerX =
+            butterflies.reduce((sum, b) => sum + b.x - b.width / 2, 0) /
+            butterflies.length;
+        const centerY =
+            butterflies.reduce((sum, b) => sum + b.y - b.height / 2, 0) /
+            butterflies.length;
+        if (butterflies.length >= 10) {
+            this.sparkles.burst(centerX, centerY, 70, {
+                speed: 0.26,
+                scale: 1.25,
+                lifeMs: 1100,
+            });
+        } else {
+            this.sparkles.burst(centerX, centerY, 6 + butterflies.length * 2, {
+                scale: 0.9,
+            });
+        }
+
         this.caputuredButterflies.push(...butterflies);
         this.updateScoreMessage();
 

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -3,6 +3,7 @@ import * as PIXI from "pixi.js";
 import { GameStateManager } from "./GameStateManager";
 import { AudioManager } from "../utils/AudioManager";
 import { isMobileDevice } from "../utils/MobileDetection";
+import { SparkleEmitter } from "../components/SparkleEmitter";
 import { LineDrawer } from "../components/LineDrawer";
 import { Sun } from "../components/Sun";
 import { ResultState } from "./ResultState";
@@ -43,6 +44,8 @@ export class GameplayState extends StateBase {
     private gatherDistance: number = 0;
     private fontColor: number = 0x000000;
     private lastTickStep: number = -1;
+    private sparkles!: SparkleEmitter;
+    private trailElapsed: number = 0;
 
     constructor(manager: GameStateManager, stageInfo: StageInformation) {
         super(manager);
@@ -164,6 +167,10 @@ export class GameplayState extends StateBase {
             this.togglePause();
         };
 
+        // キラキラ用パーティクル(最前面に重ねる)
+        this.sparkles = new SparkleEmitter(this.createStarTexture());
+        this.container.addChild(this.sparkles);
+
         // PCはステージクリックでも一時停止できる。タッチ端末では線を引く
         // 操作と衝突するため無効 (#41)
         if (!isMobileDevice()) {
@@ -171,6 +178,15 @@ export class GameplayState extends StateBase {
                 this.togglePause();
             };
             app.stage.addEventListener("pointerdown", this.stagePauseHandler);
+        }
+    }
+
+    private createStarTexture(): PIXI.Texture {
+        try {
+            return SparkleEmitter.createStarTexture(this.manager.app.renderer);
+        } catch {
+            // テスト等でレンダラーが使えない場合のフォールバック
+            return PIXI.Texture.WHITE;
         }
     }
 
@@ -358,7 +374,24 @@ export class GameplayState extends StateBase {
             this.helpMessage.alpha -= delta / 2000;
         }
 
+        // パーティクルはpause中も動かす(余韻が固まらないように)
+        this.sparkles.update(delta);
+
         if (!this.isRunning) return;
+
+        // ボーナス蝶の軌跡キラキラ
+        this.trailElapsed += delta;
+        if (this.trailElapsed >= 60) {
+            this.trailElapsed = 0;
+            this.butterflies.forEach((butterfly) => {
+                if (butterfly instanceof SpecialButterfly) {
+                    this.sparkles.trail(
+                        butterfly.x - butterfly.width / 2,
+                        butterfly.y - butterfly.height / 2,
+                    );
+                }
+            });
+        }
 
         // ↑ pause中でも動く処理、↓ pause中は動かない処理
 
@@ -422,6 +455,7 @@ export class GameplayState extends StateBase {
     }
 
     onExit(): void {
+        this.sparkles.clear();
         if (this.stagePauseHandler) {
             this.manager.app.stage.removeEventListener(
                 "pointerdown",

--- a/src/scripts/scenes/GameplayState.ts
+++ b/src/scripts/scenes/GameplayState.ts
@@ -591,23 +591,15 @@ export class GameplayState extends StateBase {
             butterflies.length >= 10 ? "se_capture_many" : "se_capture",
         );
 
-        // 捕まえた蝶たちの中心からキラキラを散らす(多いほど盛大に)
-        const centerX =
-            butterflies.reduce((sum, b) => sum + b.x - b.width / 2, 0) /
-            butterflies.length;
-        const centerY =
-            butterflies.reduce((sum, b) => sum + b.y - b.height / 2, 0) /
-            butterflies.length;
+        // 10匹以上の大量捕獲時だけ、淡いきらきらを舞い降らせる
         if (butterflies.length >= 10) {
-            this.sparkles.burst(centerX, centerY, 70, {
-                speed: 0.26,
-                scale: 1.25,
-                lifeMs: 1100,
-            });
-        } else {
-            this.sparkles.burst(centerX, centerY, 6 + butterflies.length * 2, {
-                scale: 0.9,
-            });
+            const centerX =
+                butterflies.reduce((sum, b) => sum + b.x - b.width / 2, 0) /
+                butterflies.length;
+            const centerY =
+                butterflies.reduce((sum, b) => sum + b.y - b.height / 2, 0) /
+                butterflies.length;
+            this.sparkles.shower(centerX, centerY, 45);
         }
 
         this.caputuredButterflies.push(...butterflies);

--- a/tests/setup/test-setup.ts
+++ b/tests/setup/test-setup.ts
@@ -30,6 +30,15 @@ Object.defineProperty(window, "HTMLCanvasElement", {
     })),
 });
 
+// pixi-filters はWebGL前提なのでテストではスタブする
+vi.mock("pixi-filters", () => ({
+    GlowFilter: class {
+        outerStrength = 0;
+        innerStrength = 0;
+        color = 0xffffff;
+    },
+}));
+
 // Webpack DefinePlugin globals (see webpack.config.cjs)
 vi.stubGlobal("BASE_URL", "/");
 vi.stubGlobal("DEBUG_MODE", false);

--- a/tests/unit/components/SparkleEmitter.test.ts
+++ b/tests/unit/components/SparkleEmitter.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock PIXI.js (LineDrawer.test.tsと同様のローカルモック)
+vi.mock("pixi.js", () => ({
+    Container: class {
+        children: unknown[] = [];
+        addChild(c: unknown) {
+            this.children.push(c);
+            return c;
+        }
+        removeChild(c: unknown) {
+            this.children = this.children.filter((x) => x !== c);
+            return c;
+        }
+    },
+    Sprite: class {
+        x = 0;
+        y = 0;
+        alpha = 1;
+        rotation = 0;
+        tint = 0xffffff;
+        blendMode = "normal";
+        anchor = { set: vi.fn() };
+        scale = {
+            _v: 1,
+            set(v: number) {
+                this._v = v;
+            },
+        };
+        destroyed = false;
+        texture: unknown;
+        constructor(texture?: unknown) {
+            this.texture = texture;
+        }
+        destroy() {
+            this.destroyed = true;
+        }
+    },
+}));
+
+import { SparkleEmitter } from "../../../src/scripts/components/SparkleEmitter";
+
+const fakeTexture = { fake: "star" };
+
+describe("SparkleEmitter", () => {
+    let emitter: SparkleEmitter;
+
+    beforeEach(() => {
+        emitter = new SparkleEmitter(fakeTexture as never);
+    });
+
+    it("should spawn the requested number of particles on burst", () => {
+        emitter.burst(100, 200, 30);
+        expect(emitter.particleCount).toBe(30);
+    });
+
+    it("should spawn a single trail particle near the given position", () => {
+        emitter.trail(50, 60);
+        expect(emitter.particleCount).toBe(1);
+    });
+
+    it("should fade and remove particles after their lifetime", () => {
+        emitter.burst(0, 0, 10, { lifeMs: 500 });
+        emitter.update(250);
+        expect(emitter.particleCount).toBe(10);
+
+        emitter.update(400); // 合計650ms > 500ms
+        expect(emitter.particleCount).toBe(0);
+    });
+
+    it("should move particles over time", () => {
+        emitter.burst(0, 0, 5, { lifeMs: 1000 });
+        const before = emitter.children.map((c) => ({
+            x: (c as { x: number }).x,
+            y: (c as { y: number }).y,
+        }));
+        emitter.update(300);
+        const after = emitter.children.map((c) => ({
+            x: (c as { x: number }).x,
+            y: (c as { y: number }).y,
+        }));
+        const moved = after.some(
+            (p, i) => p.x !== before[i].x || p.y !== before[i].y,
+        );
+        expect(moved).toBe(true);
+    });
+
+    it("should enforce the particle cap", () => {
+        for (let i = 0; i < 10; i++) {
+            emitter.burst(0, 0, 100);
+        }
+        expect(emitter.particleCount).toBeLessThanOrEqual(300);
+    });
+});

--- a/tests/unit/components/SparkleEmitter.test.ts
+++ b/tests/unit/components/SparkleEmitter.test.ts
@@ -85,6 +85,17 @@ describe("SparkleEmitter", () => {
         expect(moved).toBe(true);
     });
 
+    it("should spawn falling particles with a shower", () => {
+        emitter.shower(100, 100, 20);
+        expect(emitter.particleCount).toBe(20);
+        emitter.update(300);
+        const falling = emitter.children.filter(
+            (c) => (c as { y: number }).y > 40,
+        );
+        // 大半が下方向に動いている(初期位置はy=100±40)
+        expect(falling.length).toBeGreaterThan(10);
+    });
+
     it("should enforce the particle cap", () => {
         for (let i = 0; i < 10; i++) {
             emitter.burst(0, 0, 100);

--- a/tests/unit/components/SparkleEmitter.test.ts
+++ b/tests/unit/components/SparkleEmitter.test.ts
@@ -96,6 +96,18 @@ describe("SparkleEmitter", () => {
         expect(falling.length).toBeGreaterThan(10);
     });
 
+    it("should shower over sampled positions", () => {
+        let calls = 0;
+        emitter.showerOver(15, () => {
+            calls++;
+            return { x: calls * 10, y: 0 };
+        });
+        expect(calls).toBe(15);
+        expect(emitter.particleCount).toBe(15);
+        const xs = emitter.children.map((c) => (c as { x: number }).x);
+        expect(Math.max(...xs) - Math.min(...xs)).toBeGreaterThan(100);
+    });
+
     it("should enforce the particle cap", () => {
         for (let i = 0; i < 10; i++) {
             emitter.burst(0, 0, 100);


### PR DESCRIPTION
## 概要 / Summary

ボーナス蝶のリデザインと大量捕獲のきらきら演出を追加します。
Redesign the special butterfly and add a sparkle shower for big captures.

close: #10
close: #4

## 変更内容 / Changes

### ✨ ボーナス蝶リデザイン (#10)
- 旧: luminosityブレンド+星屑テクスチャのマスク
- 新: **温白色のグローが脈動**(pixi-filters v6.1.5のGlowFilter — PIXI v8対応、蝶だけに適用)+ **飛跡に光の粒がこぼれる**
- 星テクスチャはコード生成(柔らかいハロー付き、画像素材なし)

### 🌟 大量捕獲のきらきら (#4)
- 10匹以上捕獲時、**囲んだループの形の内側全体**から淡い光の粒(透明度60%)がゆっくり舞い降りる
- 粒数は領域の広さに連動(45〜90個)。通常捕獲(2〜9匹)は演出なし(プレイテストで調整)
- #4のflower発光は「現状で十分目立っている」ためユーザー判断で見送り。ループ完成リング演出も試作後に不採用

### 実装 / Implementation
- 新規 `SparkleEmitter`: 依存なしのスプライトベース・パーティクル(通常合成 — 加算合成は明るい背景で白飛びするため)。上限300で暴走防止。ユニットテスト7件(TDD)
- pixi-filters はGlowFilterのみtree-shakenで取り込み

## 性能 / Performance

- フィルタは小さいスプライト1体のみ、パーティクルは上限300のスプライト → 計測でも**FPSは表示上限に張り付き**(120Hz機で120fps)。通常スペックのノートPCで問題なし
- テスト: 全319件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)