### PR TITLE
Fix Japanese menu text overflow and remove new-record SE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,12 @@ npm run test:e2e:debug     # Debug E2E tests step-by-step
     - When working on GitHub Issues, create a Pull Request after completing tasks. Include "close: #{issue}" in the PR description to auto-close the issue when merged
 
 4. **多言語対応**: IssueやPullRequestは日本語と英語を併記しておくこと
+
     - Write Issues and Pull Requests in both Japanese and English
+
+5. **作業終了後は開発サーバーを起動しておく**: 見た目や挙動に関わる作業が終わったら、`npm start` で開発サーバーを起動した状態で終了し、ユーザーがすぐ `http://localhost:1234/` で最新の成果物を確認できるようにすること。ポート1234が既に使用中の場合は、そのプロセスをkillしてから起動してよい
+
+    - After finishing work that affects appearance or behavior, leave `npm start` running so the user can immediately check the latest result at `http://localhost:1234/`. If port 1234 is already in use, it's fine to kill that process and start a fresh dev server
 
 ### MANDATORY: Pre-Commit and Pre-Push Workflow
 

--- a/src/scripts/components/Button.ts
+++ b/src/scripts/components/Button.ts
@@ -22,13 +22,19 @@ export class Button extends BaseCaptureableObject {
         super();
         this.leafSprite = new PIXI.Sprite(PIXI.Texture.from(textureAlias));
         this.leafSprite.scale.set(0.5);
+        this.leafSprite.anchor.set(0.5);
+        this.leafSprite.position.set(
+            this.leafSprite.width / 2,
+            this.leafSprite.height / 2,
+        );
+        this.leafSprite.rotation = Math.PI / 3;
         this.addChild(this.leafSprite);
 
+        const font = Button.fontStyleFor(text);
         this.buttonText = new PIXI.Text({
             text: text,
             style: {
-                ...Button.fontStyleFor(text),
-                fontSize: 30,
+                ...font,
                 fill: "#ffffff",
                 align: "center",
             },
@@ -36,7 +42,7 @@ export class Button extends BaseCaptureableObject {
         this.addChild(this.buttonText);
         this.buttonText.anchor.set(0.5);
         this.buttonText.x = (1.1 * this.leafSprite.width) / 2;
-        this.buttonText.y = this.leafSprite.height / 2;
+        this.buttonText.y = this.leafSprite.height / 2 + font.fontSize / 3;
 
         this.x = x;
         this.y = y;
@@ -45,21 +51,28 @@ export class Button extends BaseCaptureableObject {
         this.hitRate = 0.3;
     }
 
-    /** 表示テキストに応じて日本語/英語フォントを選ぶ */
+    /**
+     * 表示テキストに応じて日本語/英語フォントを選ぶ。
+     * 日本語は全角文字で幅を取り葉からはみ出しやすいため、英語よりやや
+     * 小さめのfontSizeにする
+     */
     private static fontStyleFor(text: string): {
         fontFamily: string;
         fontWeight: PIXI.TextStyleFontWeight;
+        fontSize: number;
     } {
         return isJapaneseText(text)
             ? {
                   fontFamily: Const.FONT_JAPANESE,
                   fontWeight:
                       Const.FONT_JAPANESE_BOLD as PIXI.TextStyleFontWeight,
+                  fontSize: 24,
               }
             : {
                   fontFamily: Const.FONT_ENGLISH,
                   fontWeight:
                       Const.FONT_ENGLISH_BOLD as PIXI.TextStyleFontWeight,
+                  fontSize: 30,
               };
     }
 
@@ -69,6 +82,7 @@ export class Button extends BaseCaptureableObject {
         const font = Button.fontStyleFor(text);
         this.buttonText.style.fontFamily = font.fontFamily;
         this.buttonText.style.fontWeight = font.fontWeight;
+        this.buttonText.style.fontSize = font.fontSize;
     }
 
     /**

--- a/src/scripts/scenes/ResultState.ts
+++ b/src/scripts/scenes/ResultState.ts
@@ -212,7 +212,6 @@ export class ResultState extends StateBase {
                     this.stageInfo.totalScore,
                 );
                 if (isNewRecord) {
-                    AudioManager.shared.playSe("se_applause");
                     this.recordMessage = new Message(t("result.newRecord"), 24);
                 } else if (previousBest !== null) {
                     this.recordMessage = new Message(


### PR DESCRIPTION
## Summary / 概要

- Japanese leaf-shaped menu buttons (「あそびかた」「スタート」「れんしゅう」など) were overflowing the leaf artwork because full-width glyphs are wider than the leaf's default orientation allows. Reduced the Japanese font size (30→24), rotated the leaf 60° to give more horizontal room along its long axis, and nudged the text down slightly (fontSize/3) so it sits centered in the shape for both languages.
- Removed the applause SE (`se_applause`) that played in `ResultState` when the player set a new personal record.
- Documented a new mandatory workflow rule in `CLAUDE.md`: leave `npm start` running after finishing work so the user can immediately preview the result at `http://localhost:1234/`.

日本語のメニューボタン(「あそびかた」「スタート」「れんしゅう」など)が、全角文字の幅により葉っぱの絵柄からはみ出していたため、日本語フォントサイズを30→24に縮小し、葉を60度回転させて長軸方向の横幅を確保、さらにテキストを少し(フォントサイズの1/3ほど)下にずらして中央に収まるよう調整しました。
また、記録更新時に鳴っていた拍手SE(`se_applause`)を削除しました。
あわせて、作業終了後は`npm start`を起動したままにしてユーザーがすぐ`http://localhost:1234/`で成果物を確認できるようにする、というルールを`CLAUDE.md`に追記しました。

## Test plan / テスト計画

- [x] `npm test` — 290 unit/rendering/scene tests pass (the only failing suite, `DevServer.test.ts`, fails due to an unrelated local port conflict, not this change)
- [x] `npm run lint:fix` — clean
- [x] Verified visually via local dev server + Playwright screenshots in both Japanese and English: menu labels ("あそびかた"/"スタート"/"れんしゅう", "How to play"/"Start") now fit inside the leaf without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)