### PR TITLE
Allow one retry per run on game over

### DIFF
--- a/src/scripts/components/StageInformation.ts
+++ b/src/scripts/components/StageInformation.ts
@@ -53,6 +53,8 @@ export class StageInformation {
     bonusFlag: boolean = false;
     // プラクティスモード(記録・スコア保存を行わない再挑戦プレイ)かどうか
     isPractice: boolean = false;
+    // 1回だけ使えるリトライを使い切ったかどうか(ラン全体で1回のみ)
+    retryUsed: boolean = false;
 
     constructor(startLevel: number = 1) {
         // initial level (プラクティスモードでは任意のレベルから開始できる)
@@ -134,6 +136,23 @@ export class StageInformation {
         this.bonusPoint = this.bonusCount * 100;
         this.stageTotalScore = this.stagePoint + this.bonusPoint;
         this.totalScore += this.stageTotalScore;
+    }
+
+    /**
+     * 失敗時に1回だけ使えるリトライ。同じレベルを最初からやり直す。
+     * calcScore()が既にtotalScoreへ加算した失敗分のスコアを取り消してから、
+     * 挑戦カウンタをリセットする(ラン全体で1回のみ、retryUsedで管理)。
+     */
+    retry(): void {
+        this.totalScore -= this.stageTotalScore;
+        this.retryUsed = true;
+        this.setConfig(this.level);
+        this.captureCount = 0;
+        this.stagePoint = 0;
+        this.bonusCount = 0;
+        this.bonusPoint = 0;
+        this.stageTotalScore = 0;
+        this.isClear = false;
     }
 
     next(): void {

--- a/src/scripts/scenes/ResultState.ts
+++ b/src/scripts/scenes/ResultState.ts
@@ -29,6 +29,8 @@ export class ResultState extends StateBase {
     private backToStartButton!: Button;
     // 失敗直後、まだリトライが残っている場合だけ生成される
     private retryButton?: Button;
+    // 「1回だけ」であることを伝える、retryButtonと同時にのみ表示するヒント
+    private retryHintMessage?: Message;
     private nextMessage!: Message;
     private recordMessage?: Message;
     private lineDrawer!: LineDrawer;
@@ -230,6 +232,14 @@ export class ResultState extends StateBase {
             );
             this.container.addChild(this.retryButton);
             this.container.addChild(this.backToStartButton);
+
+            // ボタンだけでは「1回だけ」だと伝わらないため、一言添える
+            this.retryHintMessage = new Message(t("result.retryHint"), 18);
+            this.retryHintMessage.anchor.set(0.5);
+            this.retryHintMessage.x = this.manager.app.screen.width / 2;
+            this.retryHintMessage.y = this.manager.app.screen.height * 0.68;
+            this.container.addChild(this.retryHintMessage);
+            this.retryHintMessage.show();
         } else {
             // ゲームオーバー(リトライを使い切った、または元々対象外)、
             // またはプラクティスモードでのクリアの場合は、次のステージへは
@@ -553,6 +563,9 @@ export class ResultState extends StateBase {
                 this.fadeOut(this.backToStartButton),
                 this.fadeOut(this.nextMessage),
                 this.fadeOut(this.stickySprite),
+                ...(this.retryHintMessage
+                    ? [this.fadeOut(this.retryHintMessage)]
+                    : []),
             ]);
             // 同じレベルを最初からやり直す(このランはまだ確定していないので保存しない)
             this.stageInfo.retry();
@@ -584,6 +597,9 @@ export class ResultState extends StateBase {
                 this.fadeOut(this.stickySprite),
                 ...(this.recordMessage
                     ? [this.fadeOut(this.recordMessage)]
+                    : []),
+                ...(this.retryHintMessage
+                    ? [this.fadeOut(this.retryHintMessage)]
                     : []),
             ]);
             // プラクティスモードはステージ選択画面へ、通常プレイはスタート画面へ戻る

--- a/src/scripts/scenes/ResultState.ts
+++ b/src/scripts/scenes/ResultState.ts
@@ -27,6 +27,8 @@ export class ResultState extends StateBase {
     private messageButterflies: Butterfly[] = [];
     private stickySprite: PIXI.Sprite;
     private backToStartButton!: Button;
+    // 失敗直後、まだリトライが残っている場合だけ生成される
+    private retryButton?: Button;
     private nextMessage!: Message;
     private recordMessage?: Message;
     private lineDrawer!: LineDrawer;
@@ -201,9 +203,37 @@ export class ResultState extends StateBase {
             this.manager.setState(
                 new GameplayState(this.manager, this.stageInfo),
             );
+        } else if (
+            !this.stageInfo.isClear &&
+            !this.stageInfo.isPractice &&
+            !this.stageInfo.retryUsed
+        ) {
+            // 失敗直後、まだ1回分のリトライが残っている場合。
+            // このランはまだ確定していないため、ここではスコアを保存せず、
+            // 「もう一度」か「メニューへ戻る」かをプレイヤーに選ばせる
+            // (保存/記録メッセージの表示はhandleLoopAreaCompleted側で行う)
+            this.lineDrawer = new LineDrawer(this.manager.app);
+            this.lineDrawer.on(
+                "loopAreaCompleted",
+                // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                this.handleLoopAreaCompleted.bind(this),
+            );
+            this.retryButton = new Button(
+                t("button.retry"),
+                this.manager.app.screen.width * 0.35,
+                this.manager.app.screen.height * 0.8,
+            );
+            this.backToStartButton = new Button(
+                t("button.backToMenu"),
+                this.manager.app.screen.width * 0.65,
+                this.manager.app.screen.height * 0.8,
+            );
+            this.container.addChild(this.retryButton);
+            this.container.addChild(this.backToStartButton);
         } else {
-            // ゲームオーバー、またはプラクティスモードでのクリアの場合は
-            // 次のステージへは進めず、メニューへ戻るボタンを表示する
+            // ゲームオーバー(リトライを使い切った、または元々対象外)、
+            // またはプラクティスモードでのクリアの場合は、次のステージへは
+            // 進めず、メニューへ戻るボタンのみを表示する
 
             // プラクティスモードでは個人記録(ハイスコア・前回スコア)を保存しない
             if (!this.stageInfo.isPractice) {
@@ -512,14 +542,44 @@ export class ResultState extends StateBase {
 
     // LineDrawerのループエリアが完成したときのハンドラ
     private async handleLoopAreaCompleted(loopArea: PIXI.Graphics) {
+        if (this.retryButton && this.retryButton.isHit(loopArea)) {
+            AudioManager.shared.playSe("se_select");
+            this.retryButton.selected();
+
+            await this.wait(300);
+
+            await Promise.all([
+                this.fadeOut(this.retryButton),
+                this.fadeOut(this.backToStartButton),
+                this.fadeOut(this.nextMessage),
+                this.fadeOut(this.stickySprite),
+            ]);
+            // 同じレベルを最初からやり直す(このランはまだ確定していないので保存しない)
+            this.stageInfo.retry();
+            this.manager.setState(
+                new GameplayState(this.manager, this.stageInfo),
+            );
+            return;
+        }
+
         if (this.backToStartButton && this.backToStartButton.isHit(loopArea)) {
             AudioManager.shared.playSe("se_select");
             this.backToStartButton.selected();
 
             await this.wait(300);
 
+            // リトライ提示中に「メニューへ戻る」を選んだ場合、このランは
+            // ここで初めて確定する。onEnter側ではまだ保存していないため、
+            // 決定した最終スコアをここで保存する(recordMessageはこの経路
+            // では出さない: リトライを蹴った直後にフェードアウトが始まる
+            // ため、表示してもほぼ読めないまま消えてしまう)
+            if (this.retryButton && !this.stageInfo.isPractice) {
+                saveResult(this.stageInfo.totalScore);
+            }
+
             await Promise.all([
                 this.fadeOut(this.backToStartButton),
+                ...(this.retryButton ? [this.fadeOut(this.retryButton)] : []),
                 this.fadeOut(this.nextMessage),
                 this.fadeOut(this.stickySprite),
                 ...(this.recordMessage

--- a/src/scripts/utils/Language.ts
+++ b/src/scripts/utils/Language.ts
@@ -85,7 +85,7 @@ const CATALOG = {
         en: "Your total score\r {score}",
     },
     "result.retryHint": {
-        ja: "1回だけ復活できます",
+        ja: "1回だけリトライできるよ",
         en: "You can retry once",
     },
     "result.newRecord": { ja: "しんきろく！", en: "New Record!" },

--- a/src/scripts/utils/Language.ts
+++ b/src/scripts/utils/Language.ts
@@ -84,6 +84,10 @@ const CATALOG = {
         ja: "Score \r {score}",
         en: "Your total score\r {score}",
     },
+    "result.retryHint": {
+        ja: "1回だけ復活できます",
+        en: "You can retry once",
+    },
     "result.newRecord": { ja: "しんきろく！", en: "New Record!" },
     "result.best": { ja: "ベスト: {score}", en: "Best: {score}" },
     "result.need": {

--- a/src/scripts/utils/Language.ts
+++ b/src/scripts/utils/Language.ts
@@ -27,6 +27,7 @@ const CATALOG = {
     "button.back": { ja: "もどる", en: "Back" },
     "button.next": { ja: "つぎへ", en: "Next" },
     "button.backToMenu": { ja: "メニュー", en: "Menu" },
+    "button.retry": { ja: "もう一度", en: "Retry" },
     "button.practice": { ja: "れんしゅう", en: "Practice" },
 
     // --- れんしゅうモード(PracticeSelectState) ---

--- a/tests/unit/components/StageInformation.test.ts
+++ b/tests/unit/components/StageInformation.test.ts
@@ -346,6 +346,47 @@ describe("StageInformation", () => {
         });
     });
 
+    describe("retry", () => {
+        it("should default retryUsed to false", () => {
+            const si = new StageInformation();
+            expect(si.retryUsed).toBe(false);
+        });
+
+        it("should reset the current attempt but keep the same level/needCount", () => {
+            const si = new StageInformation(5);
+            si.captureCount = si.needCount - 1;
+            si.stagePoint = 300;
+            si.calcScore(); // 失敗扱い(未クリア)。totalScoreにstagePointが加算される
+
+            const needCountBeforeRetry = si.needCount;
+            const totalScoreBeforeRetry = si.totalScore;
+
+            si.retry();
+
+            expect(si.level).toBe(5);
+            expect(si.needCount).toBe(needCountBeforeRetry);
+            expect(si.retryUsed).toBe(true);
+            expect(si.captureCount).toBe(0);
+            expect(si.stagePoint).toBe(0);
+            expect(si.bonusPoint).toBe(0);
+            expect(si.stageTotalScore).toBe(0);
+            expect(si.isClear).toBe(false);
+            // 失敗した挑戦分の得点はtotalScoreから取り消される
+            expect(si.totalScore).toBe(totalScoreBeforeRetry - 300);
+        });
+
+        it("should not let totalScore go negative when the failed attempt scored nothing", () => {
+            const si = new StageInformation();
+            si.captureCount = 0;
+            si.stagePoint = 0;
+            si.calcScore();
+
+            si.retry();
+
+            expect(si.totalScore).toBe(0);
+        });
+    });
+
     describe("bonusStage", () => {
         it("should enter bonus mode with randomized settings in expected ranges", () => {
             const si = new StageInformation();

--- a/tests/unit/scenes/ResultState.test.ts
+++ b/tests/unit/scenes/ResultState.test.ts
@@ -249,6 +249,7 @@ describe("ResultState", () => {
 
             expect(saveResultMock).toHaveBeenCalledWith(stageInfo.totalScore);
             expect((state as any).retryButton).toBeUndefined();
+            expect((state as any).retryHintMessage).toBeUndefined();
 
             (state as any).fadeOut = vi.fn().mockResolvedValue(undefined);
             (state as any).wait = vi.fn().mockResolvedValue(undefined);
@@ -288,6 +289,11 @@ describe("ResultState", () => {
             expect(saveResultMock).not.toHaveBeenCalled();
             expect((state as any).retryButton).toBeDefined();
             expect((state as any).backToStartButton).toBeDefined();
+            // 「1回だけ」であることが伝わるヒントを添える
+            expect((state as any).retryHintMessage).toBeDefined();
+            expect((state as any).retryHintMessage.text).toBe(
+                t("result.retryHint"),
+            );
         });
 
         it("never offers a retry in practice mode, even before retryUsed is set", async () => {
@@ -298,6 +304,7 @@ describe("ResultState", () => {
 
             expect((state as any).retryButton).toBeUndefined();
             expect((state as any).backToStartButton).toBeDefined();
+            expect((state as any).retryHintMessage).toBeUndefined();
         });
 
         it("restarts the same level and does not save the score when retry is chosen", async () => {

--- a/tests/unit/scenes/ResultState.test.ts
+++ b/tests/unit/scenes/ResultState.test.ts
@@ -237,14 +237,18 @@ describe("ResultState", () => {
         });
     });
 
-    describe("game over", () => {
+    describe("game over (retry already used)", () => {
         it("saves the score and returns to the start menu in normal play", async () => {
-            const stageInfo = makeGameOverStageInfo({ isPractice: false });
+            const stageInfo = makeGameOverStageInfo({
+                isPractice: false,
+                retryUsed: true,
+            });
             const state = new ResultState(manager as any, stageInfo, false);
             stubResultDisplay(state);
             await runOnEnter(state);
 
             expect(saveResultMock).toHaveBeenCalledWith(stageInfo.totalScore);
+            expect((state as any).retryButton).toBeUndefined();
 
             (state as any).fadeOut = vi.fn().mockResolvedValue(undefined);
             (state as any).wait = vi.fn().mockResolvedValue(undefined);
@@ -255,7 +259,10 @@ describe("ResultState", () => {
         });
 
         it("does not save the score in practice mode and returns to the practice select screen", async () => {
-            const stageInfo = makeGameOverStageInfo({ isPractice: true });
+            const stageInfo = makeGameOverStageInfo({
+                isPractice: true,
+                retryUsed: true,
+            });
             const state = new ResultState(manager as any, stageInfo, false);
             stubResultDisplay(state);
             await runOnEnter(state);
@@ -268,6 +275,75 @@ describe("ResultState", () => {
 
             expect(PracticeSelectState).toHaveBeenCalledWith(manager);
             expect(StartState).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("game over (first failure, retry available)", () => {
+        it("offers a retry and does not save the score yet in normal play", async () => {
+            const stageInfo = makeGameOverStageInfo({ isPractice: false });
+            const state = new ResultState(manager as any, stageInfo, false);
+            stubResultDisplay(state);
+            await runOnEnter(state);
+
+            expect(saveResultMock).not.toHaveBeenCalled();
+            expect((state as any).retryButton).toBeDefined();
+            expect((state as any).backToStartButton).toBeDefined();
+        });
+
+        it("never offers a retry in practice mode, even before retryUsed is set", async () => {
+            const stageInfo = makeGameOverStageInfo({ isPractice: true });
+            const state = new ResultState(manager as any, stageInfo, false);
+            stubResultDisplay(state);
+            await runOnEnter(state);
+
+            expect((state as any).retryButton).toBeUndefined();
+            expect((state as any).backToStartButton).toBeDefined();
+        });
+
+        it("restarts the same level and does not save the score when retry is chosen", async () => {
+            const stageInfo = makeGameOverStageInfo({ isPractice: false });
+            const totalScoreBeforeRetry = stageInfo.totalScore;
+            const state = new ResultState(manager as any, stageInfo, false);
+            stubResultDisplay(state);
+            await runOnEnter(state);
+
+            (state as any).fadeOut = vi.fn().mockResolvedValue(undefined);
+            (state as any).wait = vi.fn().mockResolvedValue(undefined);
+            await (state as any).handleLoopAreaCompleted(hitEverything);
+
+            expect(saveResultMock).not.toHaveBeenCalled();
+            expect(stageInfo.retryUsed).toBe(true);
+            expect(stageInfo.captureCount).toBe(0);
+            expect(GameplayState).toHaveBeenCalledWith(manager, stageInfo);
+            expect(manager.setState).toHaveBeenCalledWith(
+                expect.any(GameplayState),
+            );
+            // リトライは同じレベルのやり直しなので、失敗分のスコアは
+            // 一旦取り消され、totalScoreはリトライ前の水準に戻る
+            expect(stageInfo.totalScore).toBeLessThanOrEqual(
+                totalScoreBeforeRetry,
+            );
+        });
+
+        it("saves the final score and returns to the menu when retry is declined", async () => {
+            const stageInfo = makeGameOverStageInfo({ isPractice: false });
+            const state = new ResultState(manager as any, stageInfo, false);
+            stubResultDisplay(state);
+            await runOnEnter(state);
+
+            expect(saveResultMock).not.toHaveBeenCalled();
+
+            (state as any).fadeOut = vi.fn().mockResolvedValue(undefined);
+            (state as any).wait = vi.fn().mockResolvedValue(undefined);
+            // retryButton(画面左寄り)とbackToStartButton(画面右寄り)を
+            // 画面中央のx座標で区別し、右側だけを囲んだループを再現する
+            const hitRightSideOnly = {
+                containsPoint: (p: { x: number }) => p.x > app.screen.width / 2,
+            } as any;
+            await (state as any).handleLoopAreaCompleted(hitRightSideOnly);
+
+            expect(saveResultMock).toHaveBeenCalledWith(stageInfo.totalScore);
+            expect(StartState).toHaveBeenCalledWith(manager);
         });
     });
 });


### PR DESCRIPTION
## Summary / 概要

- Adds a single, run-wide retry: the first time a stage ends in failure (not clear, not practice mode, not already used), the result screen now offers **もう一度 (Retry)** alongside **メニュー (Menu)**, instead of ending the run immediately.
- 失敗した際、そのランでまだリトライを使っていなければ、結果画面に「もう一度」ボタンが追加で表示されるようにしました（メニューへ戻るボタンと並べて表示）。使えるのはラン全体で1回だけです。
- Choosing Retry restarts the *same level* from scratch (`StageInformation.retry()`), rolling back the failed attempt's contribution to `totalScore` so the run's total stays correct.
- 「もう一度」を選ぶと同じレベルを最初からやり直します。失敗した挑戦分のスコアはtotalScoreから取り消してから再挑戦するので、最終的なスコアがずれません。
- High score / last score is now only saved once the run is truly over (declining the retry, or failing again after it's been used) — never while a retry is still on the table, to avoid persisting a non-final score.
- ハイスコア・前回スコアの保存は「リトライを使い切った後」または「リトライを断ってメニューに戻った時点」まで遅延しました。まだランが続く可能性がある間は保存しません。
- Practice mode is unaffected (it already allows unlimited re-attempts via stage select), and bonus/dream stages never fail so they're unaffected too.
- プラクティスモード（元々やり直し自由）とボーナス/夢ステージ（そもそも失敗しない）には影響ありません。

Difficulty numbers (`stage-config.json` needCount etc.) are intentionally left untouched — the retry is scoped to be a narrow, one-time safety net, not a difficulty rebalance.

## Test plan

- [x] `npx vitest run tests/unit/components/StageInformation.test.ts` — new `retry()` tests pass
- [x] `npx vitest run tests/unit/scenes/ResultState.test.ts` — new retry-offer / decline / already-used / practice-mode scenarios pass
- [x] `npm run lint:fix` — clean
- [x] `npm test` — 570/571 pass; the 1 failure (`DevServer.test.ts`, `EADDRINUSE :::1234`) is an unrelated environment port conflict from another local dev server, not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)