### PR TITLE
Rework palette colors (orange/gold/pink) / パレット再調整(オレンジ・ゴールド・ピンク)

### DIFF
--- a/src/scripts/components/Butterfly.ts
+++ b/src/scripts/components/Butterfly.ts
@@ -83,13 +83,12 @@ export class Butterfly extends BaseCaptureableObject {
         this.spriteWith = this.sprite.width;
 
         // color change用のobject
-        // (色変え中にsubColorの色が判別しやすいよう、通常よりひと回り大きくしている)
         const ellipse = new PIXI.Graphics();
         ellipse.ellipse(
             0,
             0,
-            46 * this.sprite.scale.x,
-            58 * this.sprite.scale.x,
+            30 * this.sprite.scale.x,
+            40 * this.sprite.scale.x,
         );
         ellipse.fill(0xffffff);
         ellipse.x = 0;

--- a/src/scripts/components/Butterfly.ts
+++ b/src/scripts/components/Butterfly.ts
@@ -83,12 +83,13 @@ export class Butterfly extends BaseCaptureableObject {
         this.spriteWith = this.sprite.width;
 
         // color change用のobject
+        // (色変え中にsubColorの色が判別しやすいよう、通常よりひと回り大きくしている)
         const ellipse = new PIXI.Graphics();
         ellipse.ellipse(
             0,
             0,
-            30 * this.sprite.scale.x,
-            40 * this.sprite.scale.x,
+            46 * this.sprite.scale.x,
+            58 * this.sprite.scale.x,
         );
         ellipse.fill(0xffffff);
         ellipse.x = 0;

--- a/src/scripts/utils/Const.ts
+++ b/src/scripts/utils/Const.ts
@@ -4,13 +4,16 @@
 // - 色相を5色でまんべんなく分散(隣接する組でも最低20度以上離す)
 // - 色相が近い組(orange/gold等)は明度(Lightness)もはっきり分け、
 //   色相だけに頼らず判別できるようにする
-//   (teal .43 < orange .50 < magenta .55 < blue .59 < gold .65)
+//   (teal .43 < orange .50 < blue .59 < pink/gold .65)
 // - 彩度は基本的に高め(パステル・くすみを避ける)だが、暗くしすぎて
 //   茶色っぽく見えないよう明度は0.4を下回らないようにする
+// - pinkはmagenta寄りだと電光的に見えすぎるとのレビューを受け、
+//   色相は保ったまま明度を上げてホットピンク寄りにしている
+//   (goldとほぼ同じ明度だが、色相が70度離れているため判別には問題ない)
 export const COLOR_LIST = [
     0x2f5cff, // blue
     0x00d9b8, // teal
-    0xf91f68, // magenta(pink)
+    0xf8548a, // pink
     0xff7700, // orange
     0xfbde51, // gold(yellow)
 ] as const;

--- a/src/scripts/utils/Const.ts
+++ b/src/scripts/utils/Const.ts
@@ -1,23 +1,18 @@
 /* eslint @typescript-eslint/no-namespace: 0 */
-// 色覚特性(P型/D型など)があっても互いに見分けやすいよう、
-// IBM Design Languageの色覚配慮パレットをベースに選定。
-// Wongパレットも試したが彩度が低くくすんで見えるとのレビューがあったため、
-// より鮮やかで見分けやすいIBM版に変更した。
-// さらにIBM版のpurpleがblueと色相的に近く(約20度差)見分けづらいとの
-// レビューを受け、blueから最も離れたティール(青緑)に差し替えている。
-// orange/goldは元からHSL彩度100%だったため、明度が高くパステル寄りに
-// 見えていたblue/teal/magentaの3色だけを彩度・鮮やかさを上げる方向で調整
-// (色相の間隔は変えていないため、色覚特性での判別性は維持される)。
-// その後、実プレイでorange/gold/magentaが色変え中に見分けづらいとの指摘。
-// 原因は3色とも明度がほぼ同じ(0.48〜0.50)で色相だけが頼りだったこと。
-// orangeを暗いrust寄りに、goldを明るいyellow寄りに離し、明度差でも
-// 判別できるようにした(色相もorange/gold間を18度→25度に少し拡大)
+// 色覚特性(P型/D型など)があっても互いに見分けやすい配色。
+// 数度のレビューを経て以下を満たすよう調整済み:
+// - 色相を5色でまんべんなく分散(隣接する組でも最低20度以上離す)
+// - 色相が近い組(orange/gold等)は明度(Lightness)もはっきり分け、
+//   色相だけに頼らず判別できるようにする
+//   (teal .43 < orange .50 < magenta .55 < blue .59 < gold .65)
+// - 彩度は基本的に高め(パステル・くすみを避ける)だが、暗くしすぎて
+//   茶色っぽく見えないよう明度は0.4を下回らないようにする
 export const COLOR_LIST = [
     0x2f5cff, // blue
     0x00d9b8, // teal
     0xf91f68, // magenta(pink)
-    0xcc4400, // orange(rust寄りに暗く)
-    0xfbd460, // gold(yellow寄りに明るく)
+    0xff7700, // orange
+    0xfbde51, // gold(yellow)
 ] as const;
 
 export const SIZE_LIST = ["small", "medium", "large"] as const;

--- a/src/scripts/utils/Const.ts
+++ b/src/scripts/utils/Const.ts
@@ -7,13 +7,17 @@
 // レビューを受け、blueから最も離れたティール(青緑)に差し替えている。
 // orange/goldは元からHSL彩度100%だったため、明度が高くパステル寄りに
 // 見えていたblue/teal/magentaの3色だけを彩度・鮮やかさを上げる方向で調整
-// (色相の間隔は変えていないため、色覚特性での判別性は維持される)
+// (色相の間隔は変えていないため、色覚特性での判別性は維持される)。
+// その後、実プレイでorange/gold/magentaが色変え中に見分けづらいとの指摘。
+// 原因は3色とも明度がほぼ同じ(0.48〜0.50)で色相だけが頼りだったこと。
+// orangeを暗いrust寄りに、goldを明るいyellow寄りに離し、明度差でも
+// 判別できるようにした(色相もorange/gold間を18度→25度に少し拡大)
 export const COLOR_LIST = [
     0x2f5cff, // blue
     0x00d9b8, // teal
-    0xf0047d, // magenta
-    0xfe6100, // orange
-    0xffb000, // gold
+    0xf91f68, // magenta(pink)
+    0xcc4400, // orange(rust寄りに暗く)
+    0xfbd460, // gold(yellow寄りに明るく)
 ] as const;
 
 export const SIZE_LIST = ["small", "medium", "large"] as const;

--- a/src/scripts/utils/Const.ts
+++ b/src/scripts/utils/Const.ts
@@ -4,16 +4,13 @@
 // - 色相を5色でまんべんなく分散(隣接する組でも最低20度以上離す)
 // - 色相が近い組(orange/gold等)は明度(Lightness)もはっきり分け、
 //   色相だけに頼らず判別できるようにする
-//   (teal .43 < orange .50 < blue .59 < pink/gold .65)
+//   (teal .43 < orange .50 < blue .59 < gold .65 < pink .71)
 // - 彩度は基本的に高め(パステル・くすみを避ける)だが、暗くしすぎて
 //   茶色っぽく見えないよう明度は0.4を下回らないようにする
-// - pinkはmagenta寄りだと電光的に見えすぎるとのレビューを受け、
-//   色相は保ったまま明度を上げてホットピンク寄りにしている
-//   (goldとほぼ同じ明度だが、色相が70度離れているため判別には問題ない)
 export const COLOR_LIST = [
     0x2f5cff, // blue
     0x00d9b8, // teal
-    0xf8548a, // pink
+    0xff6bca, // pink
     0xff7700, // orange
     0xfbde51, // gold(yellow)
 ] as const;


### PR DESCRIPTION
## 概要
#70(色覚配慮パレット、PR #82でマージ済み)のフォローアップです。マージ後の実プレイで複数回フィードバックをいただき、以下の最終パレットに着地しました。

## 経緯
1. 「黄色・オレンジ・ピンクが色変え中に見分けづらい」→ 3色ともHSL明度がほぼ同じだったのが原因。明度を分ける方向で調整
2. 「(調整後の)オレンジが茶色っぽい」→ 暗くしすぎたのが原因。明るさを戻し、goldをより黄色寄りに
3. 「マゼンダをもうちょいピンクっぽく」→ 色相はそのまま、明度を引き上げてホットピンク寄りに
4. 「ピンクとオレンジが色変えだとまだわかりづらい」→ 色変え中のサブカラー表示(体の丸)を拡大してみたが、「丸は元のサイズがいい」とのことで差し戻し
5. ピンクを指定色 `#ff6bca` に変更(色相約321度、orange/goldとも67〜89度離れており判別に問題なし)

## 最終パレット
- blue: `0x2f5cff`
- teal: `0x00d9b8`
- pink: `0xff6bca`
- orange: `0xff7700`
- gold: `0xfbde51`

## Summary
Follow-up to #70 (colorblind-safe palette, merged in #82). Several rounds of post-merge playtesting feedback converged on this final palette.

## History
1. "Yellow/orange/pink hard to tell apart during color-switching" → near-identical HSL lightness; separated by lightness
2. "Orange now looks brown" → brightened back up, pushed gold further into yellow
3. "Magenta should look more pink" → raised lightness into hot-pink range, kept hue
4. "Pink and orange still hard to tell apart" → tried enlarging the color-change sub-color indicator (the body dot), but reviewer preferred the original size, so reverted
5. Pink set to the requested `#ff6bca` (hue ~321°, well separated from both orange and gold by 67-89°)

## Final palette
- blue: `0x2f5cff`
- teal: `0x00d9b8`
- pink: `0xff6bca`
- orange: `0xff7700`
- gold: `0xfbde51`

## Test plan
- [x] `npm test` — 574/575 pass (the 1 failure, `DevServer.test.ts`, is a pre-existing local port conflict unrelated to this change)
- [x] `npm run lint:fix` — clean
- [x] Manually verified in a running dev server